### PR TITLE
Fix arrow keys and other control-sequences

### DIFF
--- a/src/ansi-shell/readline/readline.js
+++ b/src/ansi-shell/readline/readline.js
@@ -27,9 +27,6 @@ import { CSI_HANDLERS } from "./rl_csi_handlers.js";
 
 const decoder = new TextDecoder();
 
-const CHAR_LF = '\n'.charCodeAt(0);
-const CHAR_CR = '\r'.charCodeAt(0);
-
 const cc = chr => chr.charCodeAt(0);
 
 const ReadlineProcessorBuilder = builder => builder
@@ -65,7 +62,7 @@ const ReadlineProcessorBuilder = builder => builder
     .state('start', async ctx => {
         const { consts, vars, externs, locals } = ctx;
 
-        if ( locals.byte === consts.CHAR_LF ) {
+        if ( locals.byte === consts.CHAR_LF || locals.byte === consts.CHAR_CR ) {
             externs.out.write('\n');
             ctx.setState('end');
             return;


### PR DESCRIPTION
Fixes #20.

## Before:

[Peek 2024-02-16 14-35 arrow keys before.webm](https://github.com/HeyPuter/phoenix/assets/222642/d7146de8-0844-4db4-9d10-60b80cbe548b)

You can see that up/down prints garbage instead of showing command history. But, up+return does execute `help` again.

## After:

[Peek 2024-02-16 14-36 arrow keys after.webm](https://github.com/HeyPuter/phoenix/assets/222642/414c89b5-3d2a-4ada-8c7f-472174ed988a)