### PR TITLE
Add a basic test harness for builtin coreutil functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ANSI Terminal for Puter",
   "main": "exports.js",
   "scripts": {
-    "test": "mocha --recursive ./test"
+    "test": "mocha ./test"
   },
   "author": "Puter Technologies Inc.",
   "license": "AGPL-3.0-only",

--- a/src/puter-shell/coreutils/basename.js
+++ b/src/puter-shell/coreutils/basename.js
@@ -29,6 +29,9 @@ export default {
         if (string === undefined) {
             throw new Error('basename: Missing path argument');
         }
+        if (ctx.locals.positionals.length > 2) {
+            throw new Error('basename: Too many arguments, expected 1 or 2');
+        }
 
         // https://pubs.opengroup.org/onlinepubs/9699919799/utilities/basename.html
 

--- a/src/puter-shell/coreutils/coreutil_lib/echo_escapes.js
+++ b/src/puter-shell/coreutils/coreutil_lib/echo_escapes.js
@@ -73,7 +73,6 @@ const echo_escapes = {
     'b': caller => caller.output(BS),
     'c': caller => caller.outputETX(),
     'e': caller => caller.output(ESC),
-    'e': caller => caller.output(ESC),
     'f': caller => caller.output(FF),
     'n': caller => caller.output('\n'),
     'r': caller => caller.output('\r'),

--- a/test/coreutils.test.js
+++ b/test/coreutils.test.js
@@ -16,10 +16,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+import { runBasenameTests } from "./coreutils/basename.js";
 import { runFalseTests } from "./coreutils/false.js";
 import { runTrueTests } from "./coreutils/true.js";
 
 describe('coreutils', function () {
+    runBasenameTests();
     runFalseTests();
     runTrueTests();
 });

--- a/test/coreutils.test.js
+++ b/test/coreutils.test.js
@@ -17,11 +17,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { runBasenameTests } from "./coreutils/basename.js";
+import { runEchoTests } from "./coreutils/echo.js";
 import { runFalseTests } from "./coreutils/false.js";
 import { runTrueTests } from "./coreutils/true.js";
 
 describe('coreutils', function () {
     runBasenameTests();
+    runEchoTests();
     runFalseTests();
     runTrueTests();
 });

--- a/test/coreutils.test.js
+++ b/test/coreutils.test.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { runFalseTests } from "./coreutils/false.js";
+import { runTrueTests } from "./coreutils/true.js";
+
+describe('coreutils', function () {
+    runFalseTests();
+    runTrueTests();
+});

--- a/test/coreutils/basename.js
+++ b/test/coreutils/basename.js
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import assert from 'assert';
+import { MakeTestContext } from './harness.js'
+import builtins from '../../src/puter-shell/coreutils/__exports__.js';
+
+export const runBasenameTests = () => {
+    describe('basename', function () {
+        it('expects at least 1 argument', async () => {
+            let ctx = MakeTestContext(builtins.basename, {});
+            let hadError = false;
+            try {
+                await builtins.basename.execute(ctx);
+            } catch (e) {
+                hadError = true;
+            }
+            if (!hadError) {
+                assert.fail('should fail when given 0 arguments');
+            }
+            assert.equal(ctx.externs.out.output, '', 'nothing should be written to stdout');
+            // Output to stderr is allowed but not required.
+        });
+        it('expects at most 2 arguments', async () => {
+            let ctx = MakeTestContext(builtins.basename, {positionals: ['a', 'b', 'c']});
+            let hadError = false;
+            try {
+                await builtins.basename.execute(ctx);
+            } catch (e) {
+                hadError = true;
+            }
+            if (!hadError) {
+                assert.fail('should fail when given 3 arguments');
+            }
+            assert.equal(ctx.externs.out.output, '', 'nothing should be written to stdout');
+            // Output to stderr is allowed but not required.
+        });
+
+        const testCases = [
+            {
+                description: '"foo.txt" produces "foo.txt"',
+                input: ['foo.txt'],
+                expectedStdout: 'foo.txt\n'
+            },
+            {
+                description: '"./foo.txt" produces "foo.txt"',
+                input: ['./foo.txt'],
+                expectedStdout: 'foo.txt\n'
+            },
+            {
+                description: '"/a/b/c/foo.txt" produces "foo.txt"',
+                input: ['/a/b/c/foo.txt'],
+                expectedStdout: 'foo.txt\n'
+            },
+            {
+                description: 'two slashes produces "/"',
+                input: ['//'],
+                expectedStdout: '/\n'
+            },
+            {
+                description: 'a series of slashes produces "/"',
+                input: ['/////'],
+                expectedStdout: '/\n'
+            },
+            {
+                description: 'empty string produces "/"',
+                input: [''],
+                expectedStdout: '.\n'
+            },
+            {
+                description: 'trailing slashes are trimmed',
+                input: ['foo.txt/'],
+                expectedStdout: 'foo.txt\n'
+            },
+            {
+                description: 'suffix is removed from simple filename',
+                input: ['foo.txt', '.txt'],
+                expectedStdout: 'foo\n'
+            },
+            {
+                description: 'suffix is removed from path',
+                input: ['/a/b/c/foo.txt', '.txt'],
+                expectedStdout: 'foo\n'
+            },
+            {
+                description: 'suffix is removed only once',
+                input: ['/a/b/c/foo.txt.txt.txt', '.txt'],
+                expectedStdout: 'foo.txt.txt\n'
+            },
+            {
+                description: 'suffix is ignored if not found in the input',
+                input: ['/a/b/c/foo.txt', '.png'],
+                expectedStdout: 'foo.txt\n'
+            },
+            {
+                description: 'suffix is removed even if input has a trailing slash',
+                input: ['/a/b/c/foo.txt/', '.txt'],
+                expectedStdout: 'foo\n'
+            },
+        ];
+        for (const {description, input, expectedStdout} of testCases) {
+            it(description, async () => {
+                let ctx = MakeTestContext(builtins.basename, {positionals: input});
+                try {
+                    const result = await builtins.basename.execute(ctx);
+                    assert.equal(result, undefined, 'should exit successfully, returning nothing');
+                } catch (e) {
+                    assert.fail(e);
+                }
+                assert.equal(ctx.externs.out.output, expectedStdout, 'wrong output written to stdout');
+                assert.equal(ctx.externs.err.output, '', 'nothing should be written to stderr');
+            });
+        }
+    });
+}

--- a/test/coreutils/echo.js
+++ b/test/coreutils/echo.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import assert from 'assert';
+import { MakeTestContext } from './harness.js'
+import builtins from '../../src/puter-shell/coreutils/__exports__.js';
+
+export const runEchoTests = () => {
+    describe('echo', function () {
+        const testCases = [
+            {
+                description: 'empty input prints a newline',
+                input: [],
+                options: {},
+                expectedStdout: '\n'
+            },
+            {
+                description: 'single input is printed',
+                input: ['hello'],
+                options: {},
+                expectedStdout: 'hello\n'
+            },
+            {
+                description: 'multiple inputs are printed, separated by spaces',
+                input: ['hello', 'world'],
+                options: {},
+                expectedStdout: 'hello world\n'
+            },
+            {
+                description: '-n suppresses newlines',
+                input: ['hello', 'world'],
+                options: {
+                    n: true
+                },
+                expectedStdout: 'hello world'
+            },
+            // TODO: Test the `-e` option for interpreting backslash escapes.
+        ];
+        for (const {description, input, options, expectedStdout} of testCases) {
+            it(description, async () => {
+                let ctx = MakeTestContext(builtins.echo, {positionals: input, values: options});
+                try {
+                    const result = await builtins.echo.execute(ctx);
+                    assert.equal(result, undefined, 'should exit successfully, returning nothing');
+                } catch (e) {
+                    assert.fail(e);
+                }
+                assert.equal(ctx.externs.out.output, expectedStdout, 'wrong output written to stdout');
+                assert.equal(ctx.externs.err.output, '', 'nothing should be written to stderr');
+            });
+        }
+    });
+}

--- a/test/coreutils/false.js
+++ b/test/coreutils/false.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import assert from 'assert';
+import { MakeTestContext } from './harness.js'
+import builtins from '../../src/puter-shell/coreutils/__exports__.js';
+import { Exit } from "../../src/puter-shell/coreutils/coreutil_lib/exit.js";
+
+async function testFalse(options) {
+    let ctx = MakeTestContext(builtins.false, options);
+    let hadError = false;
+    try {
+        await builtins.false.execute(ctx);
+    } catch (e) {
+        assert(e instanceof Exit);
+        assert.notEqual(e.code, 0, 'returned exit code 0, meaning success');
+        hadError = true;
+    }
+    if (!hadError) {
+        assert.fail('didn\'t return an exit code');
+    }
+    assert.equal(ctx.externs.out.output, '', 'false should not write to stdout');
+    assert.equal(ctx.externs.err.output, '', 'false should not write to stderr');
+}
+
+export const runFalseTests = () => {
+    describe('false', function () {
+        it('should return a non-zero exit code, with no output', async function () {
+            await testFalse({});
+        });
+        it('should allow, but ignore, positional arguments', async function () {
+            await testFalse({positionals: ['foo', 'bar', 'baz']});
+        });
+    });
+}

--- a/test/coreutils/harness.js
+++ b/test/coreutils/harness.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Context } from "contextlink";
+
+export class WritableStringStream extends WritableStream {
+    constructor() {
+        super({
+            write: (chunk) => {
+                if (this.output_ === undefined)
+                    this.output_ = "";
+                this.output_ += chunk;
+            }
+        });
+    }
+
+    write(chunk) {
+        if (!this.writer_)
+            this.writer_ = this.getWriter();
+        return this.writer_.write(chunk);
+    }
+
+    get output() { return this.output_ || ""; }
+}
+
+// TODO: Flesh this out as needed.
+export const MakeTestContext = (command, { positionals = [],  values = {}, stdinInputs = [] }) => {
+    return new Context({
+        cmdExecState: { valid: true },
+        externs: new Context({
+            in_: new ReadableStream(stdinInputs).getReader(),
+            out: new WritableStringStream(),
+            err: new WritableStringStream(),
+            sig: null,
+        }),
+        locals: new Context({
+            args: [],
+            command,
+            positionals,
+            values,
+        }),
+        platform: new Context({}),
+        plugins: new Context({}),
+        registries: new Context({}),
+    });
+}

--- a/test/coreutils/true.js
+++ b/test/coreutils/true.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import assert from 'assert';
+import { MakeTestContext } from './harness.js'
+import builtins from '../../src/puter-shell/coreutils/__exports__.js';
+
+async function testTrue(options) {
+    let ctx = MakeTestContext(builtins.true, options);
+    try {
+        const result = await builtins.true.execute(ctx);
+        assert.equal(result, undefined);
+    } catch (e) {
+        assert.fail(e);
+    }
+    assert.equal(ctx.externs.out.output, '', 'true should not write to stdout');
+    assert.equal(ctx.externs.err.output, '', 'true should not write to stderr');
+}
+
+export const runTrueTests = () => {
+    describe('true', function () {
+        it('should execute successfully with no output', async function () {
+            await testTrue({});
+        });
+        it('should allow, but ignore, positional arguments', async function () {
+            await testTrue({positionals: ['foo', 'bar', 'baz']});
+        });
+    });
+}


### PR DESCRIPTION
This is a first attempt at making our builtins testable. It provides a mock context that lets us pass in parameters and options directly (without running parsing code) and check that the return value, and stdout/stderr outputs are as they should be.

Includes tests for `true`, `false`, `basename` and `echo`, since those do not touch the filesystem. The `echo` test is missing coverage for the `-e` and `-E` options because as far as I can tell, our `echo` doesn't perform the interpretation properly, but just skips over the escape sequence, regardless of which options are provided.