### PR TITLE
Add `dirname` and `wc` builtins, and rename `printenv` to `env`

### DIFF
--- a/src/puter-shell/coreutils/__exports__.js
+++ b/src/puter-shell/coreutils/__exports__.js
@@ -25,6 +25,7 @@ import module_changelog from './changelog.js'
 import module_clear from './clear.js'
 import module_cp from './cp.js'
 import module_dcall from './dcall.js'
+import module_dirname from './dirname.js'
 import module_echo from './echo.js'
 import module_env from './env.js'
 import module_false from './false.js'
@@ -57,6 +58,7 @@ export default {
     "clear": module_clear,
     "cp": module_cp,
     "dcall": module_dcall,
+    "dirname": module_dirname,
     "echo": module_echo,
     "env": module_env,
     "false": module_false,

--- a/src/puter-shell/coreutils/__exports__.js
+++ b/src/puter-shell/coreutils/__exports__.js
@@ -48,6 +48,7 @@ import module_touch from './touch.js'
 import module_true from './true.js'
 import module_txt2img from './txt2img.js'
 import module_usages from './usages.js'
+import module_wc from './wc.js'
 
 export default {
     "ai": module_ai,
@@ -81,4 +82,5 @@ export default {
     "true": module_true,
     "txt2img": module_txt2img,
     "usages": module_usages,
+    "wc": module_wc,
 };

--- a/src/puter-shell/coreutils/__exports__.js
+++ b/src/puter-shell/coreutils/__exports__.js
@@ -26,6 +26,7 @@ import module_clear from './clear.js'
 import module_cp from './cp.js'
 import module_dcall from './dcall.js'
 import module_echo from './echo.js'
+import module_env from './env.js'
 import module_false from './false.js'
 import module_grep from './grep.js'
 import module_help from './help.js'
@@ -35,7 +36,6 @@ import module_ls from './ls.js'
 import module_mkdir from './mkdir.js'
 import module_mv from './mv.js'
 import module_neofetch from './neofetch.js'
-import module_printenv from './printenv.js'
 import module_printhist from './printhist.js'
 import module_pwd from './pwd.js'
 import module_rm from './rm.js'
@@ -58,6 +58,7 @@ export default {
     "cp": module_cp,
     "dcall": module_dcall,
     "echo": module_echo,
+    "env": module_env,
     "false": module_false,
     "grep": module_grep,
     "help": module_help,
@@ -67,7 +68,6 @@ export default {
     "mkdir": module_mkdir,
     "mv": module_mv,
     "neofetch": module_neofetch,
-    "printenv": module_printenv,
     "printhist": module_printhist,
     "pwd": module_pwd,
     "rm": module_rm,

--- a/src/puter-shell/coreutils/dirname.js
+++ b/src/puter-shell/coreutils/dirname.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+export default {
+    name: 'dirname',
+    args: {
+        $: 'simple-parser',
+        allowPositionals: true
+    },
+    execute: async ctx => {
+        let string = ctx.locals.positionals[0];
+        const removeTrailingSlashes = (input) => {
+            return input.replace(/\/+$/, '');
+        }
+
+        if (string === undefined) {
+            throw new Error('dirname: Missing path argument');
+        }
+        if (ctx.locals.positionals.length > 1) {
+            throw new Error('dirname: Too many arguments, expected 1');
+        }
+
+        // https://pubs.opengroup.org/onlinepubs/9699919799/utilities/dirname.html
+        let skipToAfterStep8 = false;
+
+        // 1. If string is //, skip steps 2 to 5.
+        if (string !== '//') {
+            // 2. If string consists entirely of <slash> characters, string shall be set to a single <slash> character.
+            //    In this case, skip steps 3 to 8.
+            if (string === '/'.repeat(string.length)) {
+                string = '/';
+                skipToAfterStep8 = true;
+            } else {
+                // 3. If there are any trailing <slash> characters in string, they shall be removed.
+                string = removeTrailingSlashes(string);
+
+                // 4. If there are no <slash> characters remaining in string, string shall be set to a single <period> character.
+                //    In this case, skip steps 5 to 8.
+                if (string.indexOf('/') === -1) {
+                    string = '.';
+                    skipToAfterStep8 = true;
+                }
+
+                // 5. If there are any trailing non- <slash> characters in string, they shall be removed.
+                else {
+                    const lastSlashIndex = string.lastIndexOf('/');
+                    if (lastSlashIndex === -1) {
+                        string = '';
+                    } else {
+                        string = string.substring(0, lastSlashIndex);
+                    }
+                }
+            }
+        }
+
+        if (!skipToAfterStep8) {
+            // 6. If the remaining string is //, it is implementation-defined whether steps 7 and 8 are skipped or processed.
+            // NOTE: We process it normally.
+
+            // 7. If there are any trailing <slash> characters in string, they shall be removed.
+            string = removeTrailingSlashes(string);
+
+            // 8. If the remaining string is empty, string shall be set to a single <slash> character.
+            if (string.length === 0) {
+                string = '/';
+            }
+        }
+
+        // The resulting string shall be written to standard output.
+        await ctx.externs.out.write(string + '\n');
+    }
+};

--- a/src/puter-shell/coreutils/env.js
+++ b/src/puter-shell/coreutils/env.js
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 export default {
-    name: 'printenv',
+    name: 'env',
     args: {
         // TODO: add 'none-parser'
         $: 'simple-parser',

--- a/src/puter-shell/coreutils/wc.js
+++ b/src/puter-shell/coreutils/wc.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import path from "path-browserify";
+
+export default {
+    name: 'wc',
+    args: {
+        $: 'simple-parser',
+        allowPositionals: true
+    },
+    execute: async ctx => {
+        const { positionals, values } = ctx.locals;
+        const { filesystem } = ctx.platform;
+
+        const paths = [...positionals];
+        if (paths.length < 1) paths.push('-');
+
+        let perFile = [];
+        let newlinesWidth = 1;
+        let wordsWidth = 1;
+        let bytesWidth = 1;
+
+        for (const relPath of paths) {
+            let counts = {
+                filename: relPath,
+                newlines: 0,
+                words: 0,
+                bytes: 0,
+            };
+
+            let inWord = false;
+            let accumulateData = (input) => {
+                counts.bytes += input.length;
+                for (const byte of input) {
+                    const char = typeof input === 'string' ? byte : String.fromCharCode(byte);
+                    // "The wc utility shall consider a word to be a non-zero-length string of characters delimited by white space."
+                    if (/\s/.test(char)) {
+                        if (char === '\r' || char === '\n') {
+                            counts.newlines++;
+                        }
+                        inWord = false;
+                        continue;
+                    }
+                    if (!inWord) {
+                        counts.words++;
+                        inWord = true;
+                    }
+                }
+            }
+
+            if (relPath === '-') {
+                let chunk, done;
+                const nextChunk = async () => {
+                    ({ value: chunk, done } = await ctx.externs.in_.read());
+                }
+                for ( await nextChunk() ; ! done ; await nextChunk() ) {
+                    accumulateData(chunk);
+                }
+            } else {
+                // DRY: also done in mkdir
+                const absPath = relPath.startsWith('/') ? relPath :
+                    path.resolve(ctx.vars.pwd, relPath);
+                const fileData = await filesystem.read(absPath);
+                accumulateData(fileData);
+            }
+
+            newlinesWidth = Math.max(newlinesWidth, counts.newlines.toString().length);
+            wordsWidth = Math.max(wordsWidth, counts.words.toString().length);
+            bytesWidth = Math.max(bytesWidth, counts.bytes.toString().length);
+            perFile.push(counts);
+        }
+
+        let printCounts = async (count) => {
+            const paddedNewlines = count.newlines.toString().padStart(newlinesWidth, ' ');
+            const paddedWords = count.words.toString().padStart(wordsWidth, ' ');
+            const paddedBytes = count.bytes.toString().padStart(bytesWidth, ' ');
+            await ctx.externs.out.write(`${paddedNewlines} ${paddedWords} ${paddedBytes} ${count.filename}\n`);
+        }
+
+        let totalCounts = {
+            filename: 'total', // POSIX: This is locale-dependent
+            newlines: 0,
+            words: 0,
+            bytes: 0,
+        };
+        for (const count of perFile) {
+            totalCounts.newlines += count.newlines;
+            totalCounts.words += count.words;
+            totalCounts.bytes += count.bytes;
+            await printCounts(count);
+        }
+        if (perFile.length > 1) {
+            await printCounts(totalCounts);
+        }
+    }
+};

--- a/test/coreutils.test.js
+++ b/test/coreutils.test.js
@@ -18,12 +18,14 @@
  */
 import { runBasenameTests } from "./coreutils/basename.js";
 import { runEchoTests } from "./coreutils/echo.js";
+import { runEnvTests } from "./coreutils/env.js";
 import { runFalseTests } from "./coreutils/false.js";
 import { runTrueTests } from "./coreutils/true.js";
 
 describe('coreutils', function () {
     runBasenameTests();
     runEchoTests();
+    runEnvTests();
     runFalseTests();
     runTrueTests();
 });

--- a/test/coreutils.test.js
+++ b/test/coreutils.test.js
@@ -22,6 +22,7 @@ import { runEchoTests } from "./coreutils/echo.js";
 import { runEnvTests } from "./coreutils/env.js";
 import { runFalseTests } from "./coreutils/false.js";
 import { runTrueTests } from "./coreutils/true.js";
+import { runWcTests } from "./coreutils/wc.js";
 
 describe('coreutils', function () {
     runBasenameTests();
@@ -30,4 +31,5 @@ describe('coreutils', function () {
     runEnvTests();
     runFalseTests();
     runTrueTests();
+    runWcTests();
 });

--- a/test/coreutils.test.js
+++ b/test/coreutils.test.js
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { runBasenameTests } from "./coreutils/basename.js";
+import { runDirnameTests } from "./coreutils/dirname.js";
 import { runEchoTests } from "./coreutils/echo.js";
 import { runEnvTests } from "./coreutils/env.js";
 import { runFalseTests } from "./coreutils/false.js";
@@ -24,6 +25,7 @@ import { runTrueTests } from "./coreutils/true.js";
 
 describe('coreutils', function () {
     runBasenameTests();
+    runDirnameTests();
     runEchoTests();
     runEnvTests();
     runFalseTests();

--- a/test/coreutils/dirname.js
+++ b/test/coreutils/dirname.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import assert from 'assert';
+import { MakeTestContext } from './harness.js'
+import builtins from '../../src/puter-shell/coreutils/__exports__.js';
+
+export const runDirnameTests = () => {
+    describe('dirname', function () {
+        it('expects at least 1 argument', async () => {
+            let ctx = MakeTestContext(builtins.dirname, {});
+            let hadError = false;
+            try {
+                await builtins.dirname.execute(ctx);
+            } catch (e) {
+                hadError = true;
+            }
+            if (!hadError) {
+                assert.fail('should fail when given 0 arguments');
+            }
+            assert.equal(ctx.externs.out.output, '', 'nothing should be written to stdout');
+            // Output to stderr is allowed but not required.
+        });
+        it('expects at most 1 argument', async () => {
+            let ctx = MakeTestContext(builtins.dirname, {positionals: ['a', 'b']});
+            let hadError = false;
+            try {
+                await builtins.dirname.execute(ctx);
+            } catch (e) {
+                hadError = true;
+            }
+            if (!hadError) {
+                assert.fail('should fail when given 2 or more arguments');
+            }
+            assert.equal(ctx.externs.out.output, '', 'nothing should be written to stdout');
+            // Output to stderr is allowed but not required.
+        });
+
+        const testCases = [
+            {
+                description: '"foo.txt" produces "."',
+                input: 'foo.txt',
+                expectedStdout: '.\n'
+            },
+            {
+                description: '"./foo.txt" produces "."',
+                input: './foo.txt',
+                expectedStdout: '.\n'
+            },
+            {
+                description: '"/a/b/c/foo.txt" produces "/a/b/c"',
+                input: '/a/b/c/foo.txt',
+                expectedStdout: '/a/b/c\n'
+            },
+            {
+                description: '"a/b/c/foo.txt" produces "a/b/c"',
+                input: 'a/b/c/foo.txt',
+                expectedStdout: 'a/b/c\n'
+            },
+            {
+                description: 'two slashes produces "/"',
+                input: '//',
+                expectedStdout: '/\n'
+            },
+            {
+                description: 'a series of slashes produces "/"',
+                input: '/////',
+                expectedStdout: '/\n'
+            },
+            {
+                description: 'empty string produces "/"',
+                input: '',
+                expectedStdout: '/\n'
+            },
+            {
+                description: 'trailing slashes are trimmed',
+                input: 'a/b/c////foo//',
+                expectedStdout: 'a/b/c\n'
+            },
+        ];
+        for (const {description, input, expectedStdout} of testCases) {
+            it(description, async () => {
+                let ctx = MakeTestContext(builtins.dirname, {positionals: [input]});
+                try {
+                    const result = await builtins.dirname.execute(ctx);
+                    assert.equal(result, undefined, 'should exit successfully, returning nothing');
+                } catch (e) {
+                    assert.fail(e);
+                }
+                assert.equal(ctx.externs.out.output, expectedStdout, 'wrong output written to stdout');
+                assert.equal(ctx.externs.err.output, '', 'nothing should be written to stderr');
+            });
+        }
+    });
+}

--- a/test/coreutils/env.js
+++ b/test/coreutils/env.js
@@ -16,19 +16,21 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-export default {
-    name: 'env',
-    args: {
-        // TODO: add 'none-parser'
-        $: 'simple-parser',
-        allowPositionals: false
-    },
-    execute: async ctx => {
-        const env = ctx.env;
-        const out = ctx.externs.out;
+import assert from 'assert';
+import { MakeTestContext } from './harness.js'
+import builtins from '../../src/puter-shell/coreutils/__exports__.js';
 
-        for ( const k in env ) {
-            await out.write(`${k}=${env[k]}\n`);
-        }
-    }
-};
+export const runEnvTests = () => {
+    describe('env', function () {
+        it('should return a non-zero exit code, and output the env variables', async function () {
+            let ctx = MakeTestContext(builtins.env, { env: {'a': '1', 'b': '2' } });
+            try {
+                await builtins.env.execute(ctx);
+            } catch (e) {
+                assert.fail(e);
+            }
+            assert.equal(ctx.externs.out.output, 'a=1\nb=2\n', 'env should output the env variables, one per line');
+            assert.equal(ctx.externs.err.output, '', 'env should not write to stderr');
+        });
+    });
+}

--- a/test/coreutils/harness.js
+++ b/test/coreutils/harness.js
@@ -43,7 +43,7 @@ export const MakeTestContext = (command, { positionals = [],  values = {}, stdin
     return new Context({
         cmdExecState: { valid: true },
         externs: new Context({
-            in_: new ReadableStream(stdinInputs).getReader(),
+            in_: ReadableStream.from(stdinInputs).getReader(),
             out: new WritableStringStream(),
             err: new WritableStringStream(),
             sig: null,

--- a/test/coreutils/harness.js
+++ b/test/coreutils/harness.js
@@ -39,7 +39,7 @@ export class WritableStringStream extends WritableStream {
 }
 
 // TODO: Flesh this out as needed.
-export const MakeTestContext = (command, { positionals = [],  values = {}, stdinInputs = [] }) => {
+export const MakeTestContext = (command, { positionals = [],  values = {}, stdinInputs = [], env = {} }) => {
     return new Context({
         cmdExecState: { valid: true },
         externs: new Context({
@@ -57,5 +57,6 @@ export const MakeTestContext = (command, { positionals = [],  values = {}, stdin
         platform: new Context({}),
         plugins: new Context({}),
         registries: new Context({}),
+        env: env,
     });
 }

--- a/test/coreutils/wc.js
+++ b/test/coreutils/wc.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import assert from 'assert';
+import { MakeTestContext } from './harness.js'
+import builtins from '../../src/puter-shell/coreutils/__exports__.js';
+
+export const runWcTests = () => {
+    describe('wc', function () {
+        const testCases = [
+            {
+                description: 'can read from stdin when given `-`',
+                positionals: ['-'],
+                stdin: 'Well hello friends!',
+                expectedStdout: '0 3 19 -\n',
+            },
+            {
+                description: 'reads from stdin when given no arguments',
+                positionals: [],
+                stdin: 'Well hello friends!',
+                expectedStdout: '0 3 19 -\n',
+            },
+            {
+                description: 'handles empty stdin',
+                positionals: ['-'],
+                stdin: '',
+                expectedStdout: '0 0 0 -\n',
+            },
+            {
+                description: 'counts newlines',
+                positionals: ['-'],
+                stdin: 'Well\nhello\nfriends!\n',
+                expectedStdout: '3 3 20 -\n',
+            },
+            // TODO: Test with files once the harness supports that.
+        ];
+        for (const { description, positionals, stdin, expectedStdout } of testCases) {
+            it(description, async () => {
+                let ctx = MakeTestContext(builtins.wc, { positionals, stdinInputs: [stdin] });
+                try {
+                    const result = await builtins.wc.execute(ctx);
+                    assert.equal(result, undefined, 'should exit successfully, returning nothing');
+                } catch (e) {
+                    assert.fail(e);
+                }
+                assert.equal(ctx.externs.out.output, expectedStdout, 'wrong output written to stdout');
+                assert.equal(ctx.externs.err.output, '', 'nothing should be written to stderr');
+            });
+        }
+    });
+}


### PR DESCRIPTION
`wc` is lacking options for now. I'll get to those next, but ran out of time today. :^)