### PR TITLE
Add standard command line options to wc

### DIFF
--- a/src/puter-shell/coreutils/wc.js
+++ b/src/puter-shell/coreutils/wc.js
@@ -22,7 +22,25 @@ export default {
     name: 'wc',
     args: {
         $: 'simple-parser',
-        allowPositionals: true
+        allowPositionals: true,
+        options: {
+            bytes: {
+                type: 'boolean',
+                short: 'c'
+            },
+            chars: {
+                type: 'boolean',
+                short: 'm'
+            },
+            lines: {
+                type: 'boolean',
+                short: 'l'
+            },
+            words: {
+                type: 'boolean',
+                short: 'w'
+            },
+        }
     },
     execute: async ctx => {
         const { positionals, values } = ctx.locals;
@@ -31,9 +49,18 @@ export default {
         const paths = [...positionals];
         if (paths.length < 1) paths.push('-');
 
+        let { bytes: printBytes, chars: printChars, lines: printNewlines, words: printWords } = values;
+        const anyOutputOptionsSpecified = printBytes || printChars || printNewlines || printWords;
+        if (!anyOutputOptionsSpecified) {
+            printBytes = true;
+            printNewlines = true;
+            printWords = true;
+        }
+
         let perFile = [];
         let newlinesWidth = 1;
         let wordsWidth = 1;
+        let charsWidth = 1;
         let bytesWidth = 1;
 
         for (const relPath of paths) {
@@ -41,14 +68,17 @@ export default {
                 filename: relPath,
                 newlines: 0,
                 words: 0,
+                chars: 0,
                 bytes: 0,
             };
 
             let inWord = false;
             let accumulateData = (input) => {
-                counts.bytes += input.length;
-                for (const byte of input) {
-                    const char = typeof input === 'string' ? byte : String.fromCharCode(byte);
+                const byteInput = typeof input === 'string' ? new TextEncoder().encode(input) : input;
+                const stringInput = typeof input === 'string' ? input : new TextDecoder().decode(input);
+                counts.bytes += byteInput.length;
+                counts.chars += stringInput.length;
+                for (const char of stringInput) {
                     // "The wc utility shall consider a word to be a non-zero-length string of characters delimited by white space."
                     if (/\s/.test(char)) {
                         if (char === '\r' || char === '\n') {
@@ -82,26 +112,37 @@ export default {
 
             newlinesWidth = Math.max(newlinesWidth, counts.newlines.toString().length);
             wordsWidth = Math.max(wordsWidth, counts.words.toString().length);
+            charsWidth = Math.max(charsWidth, counts.chars.toString().length);
             bytesWidth = Math.max(bytesWidth, counts.bytes.toString().length);
             perFile.push(counts);
         }
 
         let printCounts = async (count) => {
-            const paddedNewlines = count.newlines.toString().padStart(newlinesWidth, ' ');
-            const paddedWords = count.words.toString().padStart(wordsWidth, ' ');
-            const paddedBytes = count.bytes.toString().padStart(bytesWidth, ' ');
-            await ctx.externs.out.write(`${paddedNewlines} ${paddedWords} ${paddedBytes} ${count.filename}\n`);
+            let output = '';
+            const append = (string) => {
+                if (output.length !== 0) output += ' ';
+                output += string;
+            };
+
+            if (printNewlines) append(count.newlines.toString().padStart(newlinesWidth, ' '));
+            if (printWords)    append(count.words.toString().padStart(wordsWidth, ' '));
+            if (printChars)    append(count.chars.toString().padStart(charsWidth, ' '));
+            if (printBytes)    append(count.bytes.toString().padStart(bytesWidth, ' '));
+            append(`${count.filename}\n`);
+            await ctx.externs.out.write(output);
         }
 
         let totalCounts = {
             filename: 'total', // POSIX: This is locale-dependent
             newlines: 0,
             words: 0,
+            chars: 0,
             bytes: 0,
         };
         for (const count of perFile) {
             totalCounts.newlines += count.newlines;
             totalCounts.words += count.words;
+            totalCounts.chars += count.chars;
             totalCounts.bytes += count.bytes;
             await printCounts(count);
         }

--- a/src/puter-shell/coreutils/wc.js
+++ b/src/puter-shell/coreutils/wc.js
@@ -47,7 +47,14 @@ export default {
         const { filesystem } = ctx.platform;
 
         const paths = [...positionals];
-        if (paths.length < 1) paths.push('-');
+        // "If no input file operands are specified, no name shall be written and no <blank> characters preceding the
+        //  pathname shall be written."
+        // For convenience, we add '-' to paths, but make a note not to output the filename.
+        let emptyStdinPath = false;
+        if (paths.length < 1) {
+            emptyStdinPath = true;
+            paths.push('-');
+        }
 
         let { bytes: printBytes, chars: printChars, lines: printNewlines, words: printWords } = values;
         const anyOutputOptionsSpecified = printBytes || printChars || printNewlines || printWords;
@@ -128,7 +135,10 @@ export default {
             if (printWords)    append(count.words.toString().padStart(wordsWidth, ' '));
             if (printChars)    append(count.chars.toString().padStart(charsWidth, ' '));
             if (printBytes)    append(count.bytes.toString().padStart(bytesWidth, ' '));
-            append(`${count.filename}\n`);
+            // The only time emptyStdinPath is true, is if we had no file paths given as arguments. That means only one
+            // input (stdin), so this won't be called to print a "totals" line.
+            if (!emptyStdinPath) append(count.filename);
+            output += '\n';
             await ctx.externs.out.write(output);
         }
 

--- a/test/coreutils/wc.js
+++ b/test/coreutils/wc.js
@@ -33,7 +33,7 @@ export const runWcTests = () => {
                 description: 'reads from stdin when given no arguments',
                 positionals: [],
                 stdin: 'Well hello friends!',
-                expectedStdout: '0 3 19 -\n',
+                expectedStdout: '0 3 19\n',
             },
             {
                 description: 'handles empty stdin',

--- a/test/coreutils/wc.js
+++ b/test/coreutils/wc.js
@@ -47,11 +47,53 @@ export const runWcTests = () => {
                 stdin: 'Well\nhello\nfriends!\n',
                 expectedStdout: '3 3 20 -\n',
             },
+            {
+                description: '-lwc produces the default output',
+                options: { bytes: true, lines: true, words: true },
+                positionals: ['-'],
+                stdin: 'Well\nhello\nfriends!\n',
+                expectedStdout: '3 3 20 -\n',
+            },
+            {
+                description: '-l outputs only lines',
+                options: { lines: true },
+                positionals: ['-'],
+                stdin: 'Well\nhello\nmy friends!\n',
+                expectedStdout: '3 -\n',
+            },
+            {
+                description: '-w outputs only words',
+                options: { words: true },
+                positionals: ['-'],
+                stdin: 'Well\nhello\nmy friends!\n',
+                expectedStdout: '4 -\n',
+            },
+            {
+                description: '-c outputs only bytes',
+                options: { bytes: true },
+                positionals: ['-'],
+                stdin: '🖥️ Well\nhello\nmy friends!\n',
+                expectedStdout: '31 -\n',
+            },
+            {
+                description: '-m outputs only characters',
+                options: { chars: true },
+                positionals: ['-'],
+                stdin: '🖥️ Well\nhello\nmy friends!\n',
+                expectedStdout: '27 -\n',
+            },
+            {
+                description: '-lwmc outputs everything',
+                options: { bytes: true, chars: true, lines: true, words: true },
+                positionals: ['-'],
+                stdin: '🖥️ Well\nhello\nmy friends!\n',
+                expectedStdout: '3 5 27 31 -\n',
+            },
             // TODO: Test with files once the harness supports that.
         ];
-        for (const { description, positionals, stdin, expectedStdout } of testCases) {
+        for (const { description, options, positionals, stdin, expectedStdout } of testCases) {
             it(description, async () => {
-                let ctx = MakeTestContext(builtins.wc, { positionals, stdinInputs: [stdin] });
+                let ctx = MakeTestContext(builtins.wc, { positionals, values: options, stdinInputs: [stdin] });
                 try {
                     const result = await builtins.wc.execute(ctx);
                     assert.equal(result, undefined, 'should exit successfully, returning nothing');

--- a/test/coreutils/wc.js
+++ b/test/coreutils/wc.js
@@ -83,11 +83,25 @@ export const runWcTests = () => {
                 expectedStdout: '27 -\n',
             },
             {
-                description: '-lwmc outputs everything',
-                options: { bytes: true, chars: true, lines: true, words: true },
+                description: '-L outputs the maximum line length',
+                options: { 'max-line-length': true },
                 positionals: ['-'],
                 stdin: '🖥️ Well\nhello\nmy friends!\n',
-                expectedStdout: '3 5 27 31 -\n',
+                expectedStdout: '11 -\n',
+            },
+            {
+                description: '-L treats tabs as jumping to the next multiple of 8 columns',
+                options: { 'max-line-length': true },
+                positionals: ['-'],
+                stdin: 'hi\tmum\t!\n',
+                expectedStdout: '17 -\n',
+            },
+            {
+                description: '-lwmcL outputs everything',
+                options: { bytes: true, chars: true, lines: true, 'max-line-length': true, words: true },
+                positionals: ['-'],
+                stdin: '🖥️ Well\nhello\nmy friends!\n',
+                expectedStdout: '3 5 27 31 11 -\n',
             },
             // TODO: Test with files once the harness supports that.
         ];


### PR DESCRIPTION
-c: count bytes
-m: count characters (overrides -c)
-l: count newlines
-w: count words