### PR TITLE
Document builtins

### DIFF
--- a/src/puter-shell/coreutils/ai.js
+++ b/src/puter-shell/coreutils/ai.js
@@ -18,6 +18,8 @@
  */
 export default {
     name: 'ai',
+    usage: 'ai PROMPT',
+    description: 'Send PROMPT to Puter\'s AI chatbot, and print its response.',
     args: {
         $: 'simple-parser',
         allowPositionals: true,
@@ -27,7 +29,11 @@ export default {
         const [ prompt ] = positionals;
 
         if ( ! prompt ) {
-            ctx.externs.err.write('txt2img: missing prompt\n');
+            ctx.externs.err.write('ai: missing prompt\n');
+            return;
+        }
+        if ( positionals.length > 1 ) {
+            ctx.externs.err.write('ai: prompt must be wrapped in quotes\n');
             return;
         }
 
@@ -36,7 +42,7 @@ export default {
 
         let a_interface, a_method, a_args;
 
-        a_interface = 'puter-chat-completion',
+        a_interface = 'puter-chat-completion';
         a_method = 'complete';
         a_args = {
             messages: [

--- a/src/puter-shell/coreutils/basename.js
+++ b/src/puter-shell/coreutils/basename.js
@@ -18,6 +18,9 @@
  */
 export default {
     name: 'basename',
+    usage: 'basename PATH [SUFFIX]',
+    description: 'Print PATH without leading directory segments.\n\n' +
+        'If SUFFIX is provided, it is removed from the end of the result.',
     args: {
         $: 'simple-parser',
         allowPositionals: true

--- a/src/puter-shell/coreutils/cat.js
+++ b/src/puter-shell/coreutils/cat.js
@@ -20,6 +20,9 @@ import path from "path-browserify";
 
 export default {
     name: 'cat',
+    usage: 'cat [FILE...]',
+    description: 'Concatenate the FILE(s) and print the result.\n\n' +
+        'If no FILE is given, or a FILE is `-`, read the standard input.',
     args: {
         $: 'simple-parser',
         allowPositionals: true

--- a/src/puter-shell/coreutils/cd.js
+++ b/src/puter-shell/coreutils/cd.js
@@ -20,6 +20,8 @@ import path from "path-browserify";
 
 export default {
     name: 'cd',
+    usage: 'cd PATH',
+    description: 'Change the current directory to PATH.',
     args: {
         $: 'simple-parser',
         allowPositionals: true

--- a/src/puter-shell/coreutils/changelog.js
+++ b/src/puter-shell/coreutils/changelog.js
@@ -29,11 +29,13 @@ function printVersion(ctx, version) {
 
 export default {
     name: 'changelog',
+    description: 'Print the changelog for the Phoenix Shell, ordered oldest to newest.',
     args: {
         $: 'simple-parser',
         allowPositionals: false,
         options: {
             latest: {
+                description: 'Print only the changes for the most recent version',
                 type: 'boolean'
             }
         }

--- a/src/puter-shell/coreutils/clear.js
+++ b/src/puter-shell/coreutils/clear.js
@@ -18,6 +18,8 @@
  */
 export default {
     name: 'clear',
+    usage: 'clear',
+    description: 'Clear the terminal output.',
     args: {
         // TODO: add 'none-parser'
         $: 'simple-parser',

--- a/src/puter-shell/coreutils/coreutil_lib/help.js
+++ b/src/puter-shell/coreutils/coreutil_lib/help.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+export const printUsage = async (command, out) => {
+    const { name, usage, description, args } = command;
+    const { options } = args;
+
+    const heading = txt => {
+        out.write(`\x1B[34;1m${txt}:\x1B[0m\n`);
+    };
+
+    heading('Usage');
+    if (!usage) {
+        let output = name;
+        if (options) {
+            output += ' [OPTIONS]';
+        }
+        if (args.allowPositionals) {
+            output += ' INPUTS...';
+        }
+        out.write(`  ${output}\n\n`);
+    } else if (typeof usage === 'string') {
+        out.write(`  ${usage}\n\n`);
+    } else {
+        for (const line of usage) {
+            out.write(`  ${line}\n`);
+        }
+        out.write('\n');
+    }
+
+    if (description) {
+        out.write(`${description}\n\n`);
+    }
+
+    if (options) {
+        heading('Options');
+
+        for (const optionName in options) {
+            let optionText = '';
+            const option = options[optionName];
+            if (option.short) {
+                optionText += `-${option.short}, `;
+            } else {
+                optionText += `    `;
+            }
+            optionText += `--${optionName}`;
+            if (option.type !== 'boolean') {
+                const valueName = option.valueName || 'VALUE';
+                optionText += `=${valueName}`;
+            }
+            if (option.description) {
+                optionText += `\t ${option.description}`;
+            }
+            out.write(`  ${optionText}\n`);
+        }
+        out.write('\n');
+    }
+}

--- a/src/puter-shell/coreutils/cp.js
+++ b/src/puter-shell/coreutils/cp.js
@@ -21,11 +21,14 @@ import { Exit } from "./coreutil_lib/exit.js";
 
 export default {
     name: 'cp',
+    usage: ['cp [OPTIONS] SOURCE DESTINATION', 'cp [OPTIONS] SOURCE... DIRECTORY'],
+    description: 'Copy the SOURCE to DESTINATION, or multiple SOURCE(s) to DIRECTORY.',
     args: {
         $: 'simple-parser',
         allowPositionals: true,
         options: {
             recursive: {
+                description: 'Copy directories recursively',
                 type: 'boolean',
                 short: 'R'
             }

--- a/src/puter-shell/coreutils/dcall.js
+++ b/src/puter-shell/coreutils/dcall.js
@@ -18,6 +18,7 @@
  */
 export default {
     name: 'driver-call',
+    usage: 'driver-call METHOD [JSON]',
     args: {
         $: 'simple-parser',
         allowPositionals: true,

--- a/src/puter-shell/coreutils/dirname.js
+++ b/src/puter-shell/coreutils/dirname.js
@@ -18,6 +18,8 @@
  */
 export default {
     name: 'dirname',
+    usage: 'dirname PATH',
+    description: 'Print PATH without its final segment.',
     args: {
         $: 'simple-parser',
         allowPositionals: true

--- a/src/puter-shell/coreutils/echo.js
+++ b/src/puter-shell/coreutils/echo.js
@@ -20,18 +20,26 @@ import { processEscapes } from "./coreutil_lib/echo_escapes.js";
 
 export default {
     name: 'echo',
+    usage: 'echo [OPTIONS] INPUTS...',
+    description: 'Print the inputs to standard output.',
     args: {
         $: 'simple-parser',
         allowPositionals: true,
         options: {
-            n: {
-                type: 'boolean'
+            'no-newline': {
+                description: 'Do not print a trailing newline',
+                type: 'boolean',
+                short: 'n'
             },
-            e: {
-                type: 'boolean'
+            'enable-escapes': {
+                description: 'Interpret backslash escape sequences',
+                type: 'boolean',
+                short: 'e'
             },
-            E: {
-                type: 'boolean'
+            'disable-escapes': {
+                description: 'Disable interpreting backslash escape sequences',
+                type: 'boolean',
+                short: 'E'
             }
         }
     },

--- a/src/puter-shell/coreutils/env.js
+++ b/src/puter-shell/coreutils/env.js
@@ -18,6 +18,8 @@
  */
 export default {
     name: 'env',
+    usage: 'env',
+    description: 'Print environment variables, one per line, as NAME=VALUE.',
     args: {
         // TODO: add 'none-parser'
         $: 'simple-parser',

--- a/src/puter-shell/coreutils/false.js
+++ b/src/puter-shell/coreutils/false.js
@@ -20,6 +20,8 @@ import { Exit } from './coreutil_lib/exit.js';
 
 export default {
     name: 'false',
+    usage: 'false',
+    description: 'Do nothing, and return a failure code.',
     args: {
         $: 'simple-parser',
         allowPositionals: true

--- a/src/puter-shell/coreutils/grep.js
+++ b/src/puter-shell/coreutils/grep.js
@@ -22,6 +22,8 @@ import path_ from "path-browserify";
 
 export default {
     name: 'grep',
+    usage: 'grep [OPTIONS] PATTERN FILE...',
+    description: 'Search FILE(s) for PATTERN, and print any matches.',
     input: {
         syncLines: true,
     },
@@ -30,18 +32,22 @@ export default {
         allowPositionals: true,
         options: {
             'ignore-case': {
+                description: 'Match the pattern case-insensitively',
                 type: 'boolean',
                 short: 'i'
             },
             'invert-match': {
+                description: 'Print lines that do not match the pattern',
                 type: 'boolean',
                 short: 'v'
             },
             'line-number': {
+                description: 'Print the line number before each result',
                 type: 'boolean',
                 short: 'n'
             },
             recursive: {
+                description: 'Recursively search in directories',
                 type: 'boolean',
                 short: 'r'
             }

--- a/src/puter-shell/coreutils/help.js
+++ b/src/puter-shell/coreutils/help.js
@@ -16,20 +16,39 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import path from "path-browserify";
-
 // TODO: fetch help information from command registry
+
+import { printUsage } from "./coreutil_lib/help.js";
 
 export default {
     name: 'help',
+    usage: ['help', 'help COMMAND'],
+    description: 'Print help information for a specific command, or list available commands.\n' +
+        'If COMMAND is provided, print the documentation for that command. ' +
+        'Otherwise, list all the commands that are available.',
     args: {
         $: 'simple-parser',
         allowPositionals: true
     },
     execute: async ctx => {
+        const { positionals } = ctx.locals;
         const { builtins } = ctx.registries;
 
         const { out } = ctx.externs;
+
+        if (positionals.length > 1) {
+            throw new Error('help: Too many arguments, expected 0 or 1');
+        }
+
+        if (positionals.length === 1) {
+            const commandName = positionals[0];
+            const command = builtins[commandName];
+            if (!command) {
+                throw new Error(`help: No builtin found named '${commandName}'`);
+            }
+            await printUsage(command, out);
+            return;
+        }
 
         const heading = txt => {
             out.write(`\x1B[34;1m~ ${txt} ~\x1B[0m\n`);

--- a/src/puter-shell/coreutils/help.js
+++ b/src/puter-shell/coreutils/help.js
@@ -23,7 +23,7 @@ import { printUsage } from "./coreutil_lib/help.js";
 export default {
     name: 'help',
     usage: ['help', 'help COMMAND'],
-    description: 'Print help information for a specific command, or list available commands.\n' +
+    description: 'Print help information for a specific command, or list available commands.\n\n' +
         'If COMMAND is provided, print the documentation for that command. ' +
         'Otherwise, list all the commands that are available.',
     args: {

--- a/src/puter-shell/coreutils/jq.js
+++ b/src/puter-shell/coreutils/jq.js
@@ -22,6 +22,9 @@ import { Exit } from './coreutil_lib/exit.js';
 
 export default {
     name: 'jq',
+    usage: 'jq FILTER [FILE...]',
+    description: 'Process JSON input FILE(s) according to FILTER.\n\n' +
+        'Reads from standard input if no FILE is provided.',
     input: {
         syncLines: true,
     },

--- a/src/puter-shell/coreutils/login.js
+++ b/src/puter-shell/coreutils/login.js
@@ -18,6 +18,8 @@
  */
 export default {
     name: 'login',
+    usage: 'login',
+    description: 'Log in to a Puter.com account.',
     args: {
         $: 'simple-parser',
         allowPositionals: false,

--- a/src/puter-shell/coreutils/ls.js
+++ b/src/puter-shell/coreutils/ls.js
@@ -59,32 +59,41 @@ const B_to_human_readable = B => {
 
 export default {
     name: 'ls',
+    usage: 'ls [OPTIONS] [PATH...]',
+    description: 'List directory contents.',
     args: {
         $: 'simple-parser',
         allowPositionals: true,
         options: {
             all: {
+                description: 'List all entries, including those starting with `.`',
                 type: 'boolean',
                 short: 'a'
             },
             long: {
+                description: 'List entries in long format, as a table',
                 type: 'boolean',
                 short: 'l'
             },
             'human-readable': {
+                description: 'Print sizes in a human readable format (eg 12MiB, 3GiB), instead of byte counts',
                 type: 'boolean',
                 short: 'h'
             },
             time: {
-                type: 'string',
+                description: 'Specify which time to display, one of atime (access time), ctime (creation time), or mtime (modification time)',
+                type: 'string'
             },
             S: {
+                description: 'Sort the results',
                 type: 'boolean',
             },
             t: {
+                description: 'Sort by time, newest first. See --time',
                 type: 'boolean',
             },
             reverse: {
+                description: 'Reverse the sort direction',
                 type: 'boolean',
                 short: 'r',
             },

--- a/src/puter-shell/coreutils/mkdir.js
+++ b/src/puter-shell/coreutils/mkdir.js
@@ -23,11 +23,14 @@ import { EMPTY } from "../../util/singleton.js";
 // DRY: very similar to `cd`
 export default {
     name: 'mkdir',
+    usage: 'mkdir [OPTIONS] PATH',
+    description: 'Create a directory at PATH.',
     args: {
         $: 'simple-parser',
         allowPositionals: true,
         options: {
             parents: {
+                description: 'Create parent directories if they do not exist. Do not treat existing directories as an error',
                 type: 'boolean',
                 short: 'p'
             }

--- a/src/puter-shell/coreutils/mv.js
+++ b/src/puter-shell/coreutils/mv.js
@@ -20,6 +20,8 @@ import path from "path-browserify";
 
 export default {
     name: 'mv',
+    usage: 'mv SOURCE DESTINATION',
+    description: 'Move SOURCE file or directory to DESTINATION.',
     args: {
         $: 'simple-parser',
         allowPositionals: true

--- a/src/puter-shell/coreutils/neofetch.js
+++ b/src/puter-shell/coreutils/neofetch.js
@@ -39,6 +39,8 @@ const logo = `
 
 export default {
     name: 'neofetch',
+    usage: 'neofetch',
+    description: 'Print information about the system.',
     execute: async ctx => {
         const cols = [17,18,19,26,27].reverse();
         const C25 = n => `\x1B[38;5;${n}m`;

--- a/src/puter-shell/coreutils/printhist.js
+++ b/src/puter-shell/coreutils/printhist.js
@@ -18,6 +18,8 @@
  */
 export default {
     name: 'printhist',
+    usage: 'printhist',
+    description: 'Print shell history.',
     args: {
         $: 'simple-parser',
         allowPositionals: true,

--- a/src/puter-shell/coreutils/pwd.js
+++ b/src/puter-shell/coreutils/pwd.js
@@ -20,6 +20,8 @@ import path_ from "path-browserify";
 
 export default {
     name: 'pwd',
+    usage: 'pwd',
+    description: 'Print the current working directory.',
     args: {
         $: 'simple-parser',
         allowPositionals: true

--- a/src/puter-shell/coreutils/rm.js
+++ b/src/puter-shell/coreutils/rm.js
@@ -25,19 +25,24 @@ import path from "path-browserify";
 // DRY: very similar to `cd`
 export default {
     name: 'rm',
+    usage: 'rm [OPTIONS] PATH',
+    description: 'Remove the file or directory at PATH.',
     args: {
         $: 'simple-parser',
         allowPositionals: true,
         options: {
             dir: {
+                description: 'Remove empty directories',
                 type: 'boolean',
                 short: 'd'
             },
             recursive: {
+                description: 'Recursively remove directories and their contents',
                 type: 'boolean',
                 short: 'r'
             },
             force: {
+                description: 'Ignore non-existent paths, and never prompt',
                 type: 'boolean',
                 short: 'f'
             }

--- a/src/puter-shell/coreutils/rmdir.js
+++ b/src/puter-shell/coreutils/rmdir.js
@@ -25,11 +25,14 @@ import path from "path-browserify";
 // DRY: very similar to `cd`
 export default {
     name: 'rmdir',
+    usage: 'rmdir [OPTIONS] DIRECTORY',
+    description: 'Remove the DIRECTORY if it is empty.',
     args: {
         $: 'simple-parser',
         allowPositionals: true,
         options: {
             parents: {
+                description: 'Also remove empty parent directories',
                 type: 'boolean',
                 short: 'p'
             }

--- a/src/puter-shell/coreutils/tail.js
+++ b/src/puter-shell/coreutils/tail.js
@@ -18,6 +18,8 @@
  */
 export default {
     name: 'tail',
+    usage: 'tail [OPTIONS]',
+    description: 'Read standard input and print the last lines to standard output.',
     input: {
         syncLines: true
     },
@@ -26,8 +28,10 @@ export default {
         allowPositionals: true,
         options: {
             lines: {
+                description: 'Print the last COUNT lines',
                 type: 'string',
-                short: 'n'
+                short: 'n',
+                valueName: 'COUNT',
             }
         }
     },

--- a/src/puter-shell/coreutils/touch.js
+++ b/src/puter-shell/coreutils/touch.js
@@ -20,6 +20,8 @@ import path_ from "path-browserify";
 
 export default {
     name: 'touch',
+    usage: 'touch FILE...',
+    description: 'Mark the FILE(s) as accessed and modified at the current time, creating them if they do not exist.',
     args: {
         $: 'simple-parser',
         allowPositionals: true

--- a/src/puter-shell/coreutils/true.js
+++ b/src/puter-shell/coreutils/true.js
@@ -18,6 +18,8 @@
  */
 export default {
     name: 'true',
+    usage: 'true',
+    description: 'Do nothing, and return a success code.',
     args: {
         $: 'simple-parser',
         allowPositionals: true

--- a/src/puter-shell/coreutils/txt2img.js
+++ b/src/puter-shell/coreutils/txt2img.js
@@ -18,6 +18,8 @@
  */
 export default {
     name: 'txt2img',
+    usage: 'txt2img PROMPT',
+    description: 'Send PROMPT to an image-drawing AI, and print the result to standard output.',
     args: {
         $: 'simple-parser',
         allowPositionals: true,
@@ -30,12 +32,16 @@ export default {
             ctx.externs.err.write('txt2img: missing prompt\n');
             return;
         }
+        if ( positionals.length > 1 ) {
+            ctx.externs.err.write('txt2img: prompt must be wrapped in quotes\n');
+            return;
+        }
 
         const { drivers } = ctx.platform;
 
         let a_interface, a_method, a_args;
 
-        a_interface = 'puter-image-generation',
+        a_interface = 'puter-image-generation';
         a_method = 'generate';
         a_args = { prompt };
 

--- a/src/puter-shell/coreutils/usages.js
+++ b/src/puter-shell/coreutils/usages.js
@@ -18,6 +18,8 @@
  */
 export default {
     name: 'usages',
+    usage: 'usages',
+    description: 'Print usage statistics, formatted as JSON.',
     args: {
         $: 'simple-parser',
         allowPositionals: true,


### PR DESCRIPTION
![image](https://github.com/HeyPuter/phoenix/assets/222642/4ae21154-1d9b-4553-ba16-c4c74a074188)

For now, this is available only through `help COMMAND`. In the future, I'd like to make this be printed automatically for `COMMAND --help` or if we failed to parse `COMMAND`'s options and arguments, without having to manually implement this for each command.

More information is in the commit messages. I've tried to make all the documentation fields optional and still have the help text be somewhat useful.