### PR TITLE
Add `sleep` builtin command, and a stub for `man`

### DIFF
--- a/src/puter-shell/coreutils/__exports__.js
+++ b/src/puter-shell/coreutils/__exports__.js
@@ -42,6 +42,7 @@ import module_pwd from './pwd.js'
 import module_rm from './rm.js'
 import module_rmdir from './rmdir.js'
 import module_sample_data from './sample-data.js'
+import module_sleep from './sleep.js'
 import module_tail from './tail.js'
 import module_test from './test.js'
 import module_touch from './touch.js'
@@ -76,6 +77,7 @@ export default {
     "rm": module_rm,
     "rmdir": module_rmdir,
     "sample-data": module_sample_data,
+    "sleep": module_sleep,
     "tail": module_tail,
     "test": module_test,
     "touch": module_touch,

--- a/src/puter-shell/coreutils/__exports__.js
+++ b/src/puter-shell/coreutils/__exports__.js
@@ -34,6 +34,7 @@ import module_help from './help.js'
 import module_jq from './jq.js'
 import module_login from './login.js'
 import module_ls from './ls.js'
+import module_man from './man.js'
 import module_mkdir from './mkdir.js'
 import module_mv from './mv.js'
 import module_neofetch from './neofetch.js'
@@ -69,6 +70,7 @@ export default {
     "jq": module_jq,
     "login": module_login,
     "ls": module_ls,
+    "man": module_man,
     "mkdir": module_mkdir,
     "mv": module_mv,
     "neofetch": module_neofetch,

--- a/src/puter-shell/coreutils/help.js
+++ b/src/puter-shell/coreutils/help.js
@@ -55,6 +55,7 @@ export default {
         };
 
         heading('available commands');
+        out.write('Use \x1B[34;1mhelp COMMAND-NAME\x1B[0m for more information');
         for ( const k in builtins ) {
             out.write('  - ' + k + '\n');
         }

--- a/src/puter-shell/coreutils/man.js
+++ b/src/puter-shell/coreutils/man.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+export default {
+    name: 'man',
+    usage: 'man',
+    description: 'Stub command. Please use `help` instead.',
+    args: {
+        $: 'simple-parser',
+        allowPositionals: true
+    },
+    execute: async ctx => {
+        await ctx.externs.out.write('`\x1B[34;1mman\x1B[0m` is not supported. ' +
+            'Please use `\x1B[34;1mhelp COMMAND\x1B[0m` for documentation.\n');
+    }
+};

--- a/src/puter-shell/coreutils/sleep.js
+++ b/src/puter-shell/coreutils/sleep.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Exit } from './coreutil_lib/exit.js';
+
+export default {
+    name: 'sleep',
+    usage: 'sleep TIME',
+    description: 'Pause for at least TIME seconds, where TIME is a positive number.',
+    args: {
+        $: 'simple-parser',
+        allowPositionals: true
+    },
+    execute: async ctx => {
+        const { positionals } = ctx.locals;
+        if (positionals.length !== 1) {
+            await ctx.externs.err.write('sleep: Exactly one TIME parameter is required');
+            throw new Exit(1);
+        }
+
+        let time = Number.parseFloat(positionals[0]);
+        if (isNaN(time) || time < 0) {
+            await ctx.externs.err.write('sleep: Invalid TIME parameter; must be a positive number');
+            throw new Exit(1);
+        }
+
+        await new Promise(r => setTimeout(r, time * 1000));
+    }
+};

--- a/test/coreutils.test.js
+++ b/test/coreutils.test.js
@@ -21,6 +21,7 @@ import { runDirnameTests } from "./coreutils/dirname.js";
 import { runEchoTests } from "./coreutils/echo.js";
 import { runEnvTests } from "./coreutils/env.js";
 import { runFalseTests } from "./coreutils/false.js";
+import { runSleepTests } from "./coreutils/sleep.js";
 import { runTrueTests } from "./coreutils/true.js";
 import { runWcTests } from "./coreutils/wc.js";
 
@@ -30,6 +31,7 @@ describe('coreutils', function () {
     runEchoTests();
     runEnvTests();
     runFalseTests();
+    runSleepTests();
     runTrueTests();
     runWcTests();
 });

--- a/test/coreutils/sleep.js
+++ b/test/coreutils/sleep.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import assert from 'assert';
+import { MakeTestContext } from './harness.js';
+import builtins from '../../src/puter-shell/coreutils/__exports__.js';
+
+export const runSleepTests = () => {
+    describe('sleep', function () {
+        const failureCases = [
+            {
+                description: 'expects at least 1 argument',
+                positionals: [],
+            },
+            {
+                description: 'expects at most 1 argument',
+                positionals: ['1', '2'],
+            },
+            {
+                description: 'expects its argument to be a number',
+                positionals: ['frog'],
+            },
+            {
+                description: 'expects its argument to be positive',
+                positionals: ['-1'],
+            },
+        ];
+        for (const { description, positionals } of failureCases) {
+            it(description, async () => {
+                let ctx = MakeTestContext(builtins.sleep, { positionals });
+                let hadError = false;
+                try {
+                    await builtins.sleep.execute(ctx);
+                } catch (e) {
+                    hadError = true;
+                }
+                if (!hadError) {
+                    assert.fail('didn\'t return an error code');
+                }
+                assert.equal(ctx.externs.out.output, '', 'nothing should be written to stdout');
+                // Output to stderr is allowed but not required.
+            });
+        }
+
+        const testCases = [
+            {
+                description: 'sleep 0.5',
+                positionals: ['0.5'],
+                durationS: 0.5,
+            },
+            {
+                description: 'sleep 1',
+                positionals: ['1'],
+                durationS: 1,
+            },
+            {
+                description: 'sleep 1.5',
+                positionals: ['1.5'],
+                durationS: 1.5,
+            },
+        ];
+        for (const { description, positionals, durationS } of testCases) {
+            it(description, async () => {
+                let ctx = MakeTestContext(builtins.sleep, { positionals });
+                const startTimeMs = performance.now();
+                try {
+                    const result = await builtins.sleep.execute(ctx);
+                    assert.equal(result, undefined);
+                } catch (e) {
+                    assert.fail(e);
+                }
+                const endTimeMs = performance.now();
+                const actualDurationMs = endTimeMs- startTimeMs;
+                assert.ok(actualDurationMs >= (durationS * 1000), `takes at least ${durationS} seconds`);
+
+                assert.equal(ctx.externs.out.output, '', 'sleep should not write to stdout');
+                assert.equal(ctx.externs.err.output, '', 'sleep should not write to stderr');
+            });
+        }
+    });
+};


### PR DESCRIPTION
`man` just tells the user to use `help COMMAND` instead. Also added mention of that to `help`'s normal output.