### PR TITLE
Resolve ~ in paths as the home directory

### DIFF
--- a/src/ansi-shell/pipeline/Pipeline.js
+++ b/src/ansi-shell/pipeline/Pipeline.js
@@ -16,16 +16,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import path_ from "path-browserify";
-
-// DRY: used by commands as well
-const resolve = (ctx, relPath) => {
-    if ( relPath.startsWith('/') ) {
-        return relPath;
-    }
-    return path_.resolve(ctx.vars.pwd, relPath);
-};
-
 import { SyncLinesReader } from "../ioutil/SyncLinesReader.js";
 import { TOKENS } from "../readline/readtoken.js";
 import { ByteWriter } from "../ioutil/ByteWriter.js";
@@ -39,6 +29,7 @@ import { NullifyWriter } from "../ioutil/NullifyWriter.js";
 import { ConcreteSyntaxError } from "../ConcreteSyntaxError.js";
 import { SignalReader } from "../ioutil/SignalReader.js";
 import { Exit } from "../../puter-shell/coreutils/coreutil_lib/exit.js";
+import { resolveRelativePath } from '../../util/path.js';
 
 class Token {
     static createFromAST (ctx, ast) {
@@ -206,7 +197,7 @@ export class PreparedCommand {
                 ? await this.inputRedirect.resolve(this.ctx)
                 : this.inputRedirect;
             const response = await filesystem.read(
-                resolve(this.ctx, dest_path));
+                resolveRelativePath(this.ctx.vars, dest_path));
             in_ = new MemReader(response);
         }
 
@@ -316,7 +307,7 @@ export class PreparedCommand {
             const dest_path = outputRedirect instanceof Token
                 ? await outputRedirect.resolve(this.ctx)
                 : outputRedirect;
-            const path = resolve(ctx, dest_path);
+            const path = resolveRelativePath(ctx.vars, dest_path);
             console.log('it should work?', {
                 path,
                 outputMemWriters,

--- a/src/puter-shell/coreutils/cat.js
+++ b/src/puter-shell/coreutils/cat.js
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import path from "path-browserify";
+import { resolveRelativePath } from '../../util/path.js';
 
 export default {
     name: 'cat',
@@ -50,9 +50,7 @@ export default {
                 }
                 continue;
             }
-            // DRY: also done in mkdir
-            const absPath = relPath.startsWith('/') ? relPath :
-                path.resolve(ctx.vars.pwd, relPath);
+            const absPath = resolveRelativePath(ctx.vars, relPath);
 
             const result = await filesystem.read(absPath);
 

--- a/src/puter-shell/coreutils/cd.js
+++ b/src/puter-shell/coreutils/cd.js
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import path from "path-browserify";
 import { Exit } from './coreutil_lib/exit.js';
+import { resolveRelativePath } from '../../util/path.js';
 
 export default {
     name: 'cd',
@@ -34,10 +34,7 @@ export default {
         const { filesystem } = ctx.platform;
 
         let [ target ] = positionals;
-
-        if ( ! target.startsWith('/') ) {
-            target = path.resolve(ctx.vars.pwd, target);
-        }
+        target = resolveRelativePath(ctx.vars, target);
 
         const result = await filesystem.readdir(target);
 

--- a/src/puter-shell/coreutils/cp.js
+++ b/src/puter-shell/coreutils/cp.js
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import path_ from "path-browserify";
 import { Exit } from "./coreutil_lib/exit.js";
+import { resolveRelativePath } from '../../util/path.js';
 
 export default {
     name: 'cp',
@@ -54,16 +54,8 @@ export default {
 
         const dstRelPath = positionals.shift();
 
-        // DRY: also done in mkdir and cat
-        const resolve = relPath => {
-            if ( relPath.startsWith('/') ) {
-                return relPath;
-            }
-            return path_.resolve(ctx.vars.pwd, relPath);
-        }
-
-        const srcAbsPath = resolve(srcRelPath);
-        let   dstAbsPath = resolve(dstRelPath);
+        const srcAbsPath = resolveRelativePath(ctx.vars, srcRelPath);
+        let   dstAbsPath = resolveRelativePath(ctx.vars, dstRelPath);
 
         const srcStat = await filesystem.stat(srcAbsPath);
         if ( srcStat && srcStat.is_dir && ! values.recursive ) {

--- a/src/puter-shell/coreutils/grep.js
+++ b/src/puter-shell/coreutils/grep.js
@@ -16,6 +16,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+import { resolveRelativePath } from '../../util/path.js';
+
 const lxor = (a, b) => a ? !b : b;
 
 import path_ from "path-browserify";
@@ -143,9 +145,7 @@ export default {
                     await do_grep_line(value);
                 }
             } else {
-                if ( ! file.startsWith('/') ) {
-                    file = path_.resolve(ctx.vars.pwd, file);
-                }
+                file = resolveRelativePath(ctx.vars, file);
                 const stat = await filesystem.stat(file);
                 if ( stat.is_dir ) {
                     if ( values.recursive ) {

--- a/src/puter-shell/coreutils/ls.js
+++ b/src/puter-shell/coreutils/ls.js
@@ -16,10 +16,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-// INCONST: called 'path' instead of 'path_' elsewhere
-import path_ from "path-browserify";
 import columnify from "columnify";
 import cli_columns from "cli-columns";
+import { resolveRelativePath } from '../../util/path.js';
 
 // formatLsTimestamp(): written by AI
 function formatLsTimestamp(unixTimestamp) {
@@ -110,18 +109,6 @@ export default {
         const paths = positionals.length < 1
             ? [pwd] : positionals ;
 
-
-        // DRY: also done in mkdir, cat, and mv
-        const resolve = relPath => {
-            if ( relPath.startsWith('/') ) {
-                return relPath;
-            }
-            if ( relPath.startsWith('~') ) {
-                return path_.resolve(ctx.vars.home, relPath.slice(1));
-            }
-            return path_.resolve(ctx.vars.pwd, relPath);
-        }
-
         const showHeadings = paths.length > 1 ? async ({ i, path }) => {
             if ( i !== 0 ) ctx.externs.out.write('\n');
             await ctx.externs.out.write(path + ':\n');
@@ -130,7 +117,7 @@ export default {
         for ( let i=0 ; i < paths.length ; i++ ) {
             let path = paths[i];
             await showHeadings({ i, path });
-            path = resolve(path);
+            path = resolveRelativePath(ctx.vars, path);
             let result = await filesystem.readdir(path);
             console.log('ls items', result);
 

--- a/src/puter-shell/coreutils/mkdir.js
+++ b/src/puter-shell/coreutils/mkdir.js
@@ -16,10 +16,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import path from "path-browserify";
 import { validate_string } from "./coreutil_lib/validate.js";
 import { EMPTY } from "../../util/singleton.js";
 import { Exit } from './coreutil_lib/exit.js';
+import { resolveRelativePath } from '../../util/path.js';
 
 // DRY: very similar to `cd`
 export default {
@@ -53,9 +53,7 @@ export default {
             throw new Exit(1);
         }
 
-        if ( ! target.startsWith('/') ) {
-            target = path.resolve(ctx.vars.pwd, target);
-        }
+        target = resolveRelativePath(ctx.vars, target);
 
         const result = await filesystem.mkdir(target, { createMissingParents: values.parents });
 

--- a/src/puter-shell/coreutils/mv.js
+++ b/src/puter-shell/coreutils/mv.js
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import path from "path-browserify";
 import { Exit } from './coreutil_lib/exit.js';
+import { resolveRelativePath } from '../../util/path.js';
 
 export default {
     name: 'mv',
@@ -47,16 +47,8 @@ export default {
 
         const dstRelPath = positionals.shift();
 
-        // DRY: also done in mkdir and cat
-        const resolve = relPath => {
-            if ( relPath.startsWith('/') ) {
-                return relPath;
-            }
-            return path.resolve(ctx.vars.pwd, relPath);
-        }
-
-        const srcAbsPath = resolve(srcRelPath);
-        let   dstAbsPath = resolve(dstRelPath);
+        const srcAbsPath = resolveRelativePath(ctx.vars, srcRelPath);
+        let   dstAbsPath = resolveRelativePath(ctx.vars, dstRelPath);
 
         await filesystem.move(srcAbsPath, dstAbsPath);
     }

--- a/src/puter-shell/coreutils/rm.js
+++ b/src/puter-shell/coreutils/rm.js
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import path from "path-browserify";
+import { resolveRelativePath } from '../../util/path.js';
 
 // TODO: add logic to check if directory is empty
 // TODO: add check for `--dir`
@@ -55,10 +55,7 @@ export default {
         const { filesystem } = ctx.platform;
 
         let [ target ] = positionals;
-
-        if ( ! target.startsWith('/') ) {
-            target = path.resolve(ctx.vars.pwd, target);
-        }
+        target = resolveRelativePath(ctx.vars, target);
 
         await filesystem.rm(target, { recursive: values.recursive })
     }

--- a/src/puter-shell/coreutils/rmdir.js
+++ b/src/puter-shell/coreutils/rmdir.js
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import path from "path-browserify";
+import { resolveRelativePath } from '../../util/path.js';
 
 // TODO: add logic to check if directory is empty
 // TODO: add check for `--dir`
@@ -45,10 +45,7 @@ export default {
         const { filesystem } = ctx.platform;
 
         let [ target ] = positionals;
-
-        if ( ! target.startsWith('/') ) {
-            target = path.resolve(ctx.vars.pwd, target);
-        }
+        target = resolveRelativePath(ctx.vars, target);
 
         await filesystem.rmdir(target);
     }

--- a/src/puter-shell/coreutils/touch.js
+++ b/src/puter-shell/coreutils/touch.js
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import path_ from "path-browserify";
 import { Exit } from './coreutil_lib/exit.js';
+import { resolveRelativePath } from '../../util/path.js';
 
 export default {
     name: 'touch',
@@ -37,16 +37,8 @@ export default {
             throw new Exit(1);
         }
 
-        // DRY: also done in mkdir, cat, mv, and ls
-        const resolve = relPath => {
-            if ( relPath.startsWith('/') ) {
-                return relPath;
-            }
-            return path_.resolve(ctx.vars.pwd, relPath);
-        }
-
         for ( let i=0 ; i < positionals.length ; i++ ) {
-            const path = resolve(positionals[i]);
+            const path = resolveRelativePath(ctx.vars, positionals[i]);
             
             let stat = null;
             try {

--- a/src/puter-shell/coreutils/wc.js
+++ b/src/puter-shell/coreutils/wc.js
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import path from "path-browserify";
+import { resolveRelativePath } from '../../util/path.js';
 
 const TAB_SIZE = 8;
 
@@ -139,9 +139,7 @@ export default {
                     accumulateData(chunk);
                 }
             } else {
-                // DRY: also done in mkdir
-                const absPath = relPath.startsWith('/') ? relPath :
-                    path.resolve(ctx.vars.pwd, relPath);
+                const absPath = resolveRelativePath(ctx.vars, relPath);
                 const fileData = await filesystem.read(absPath);
                 accumulateData(fileData);
             }

--- a/src/puter-shell/providers/ScriptCommandProvider.js
+++ b/src/puter-shell/providers/ScriptCommandProvider.js
@@ -18,14 +18,14 @@
  */
 import path_ from "path-browserify";
 import { Pipeline } from "../../ansi-shell/pipeline/Pipeline.js";
+import { resolveRelativePath } from '../../util/path.js';
 
 export class ScriptCommandProvider {
     async lookup (id, { ctx }) {
         const is_path = id.match(/^[.\/]/);
         if ( ! is_path ) return undefined;
 
-        const absPath = id.startsWith('/') ? id :
-            path_.resolve(ctx.vars.pwd, id);
+        const absPath = resolveRelativePath(ctx.vars, id);
         
         const { filesystem } = ctx.platform;
 

--- a/src/util/path.js
+++ b/src/util/path.js
@@ -17,33 +17,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import path_ from "path-browserify";
-import { resolveRelativePath } from '../../util/path.js';
 
-export class FileCompleter {
-    async getCompetions (ctx, inputState) {
-        const { filesystem } = ctx.platform;
-
-        if ( inputState.input === '' ) {
-            return [];
-        }
-
-        let path = resolveRelativePath(ctx.vars, inputState.input);
-        let dir = path_.dirname(path);
-        let base = path_.basename(path);
-
-        const completions = [];
-
-        const result = await filesystem.readdir(dir);
-        if ( result == undefined ) {
-            return [];
-        }
-
-        for ( const item of result ) {
-            if ( item.name.startsWith(base) ) {
-                completions.push(item.name.slice(base.length));
-            }
-        }
-        
-        return completions;
+export const resolveRelativePath = (vars, relativePath) => {
+    if ( relativePath.startsWith('/') ) {
+        return relativePath;
     }
-}
+    if ( relativePath.startsWith('~') ) {
+        return path_.resolve(vars.home, '.' + relativePath.slice(1));
+    }
+    return path_.resolve(vars.pwd, relativePath);
+};


### PR DESCRIPTION
We already had code for this in `ls`, but it was buggy: removing the first character of `~/foo` produces `/foo`, which then always resolves to `/foo` regardless of what parent path you give it.

This fixes that by prepending a `.`, makes this a function in a new `utils/path.js` file, and then uses that in every location I could find that tries to resolve relative paths.

Fixes #34.