### PR TITLE
Update path.js to handle "cd" with no args

### DIFF
--- a/src/util/path.js
+++ b/src/util/path.js
@@ -19,6 +19,10 @@
 import path_ from "path-browserify";
 
 export const resolveRelativePath = (vars, relativePath) => {
+    if (!relativePath) {
+        // If relativePath is undefined, return home directory
+        return vars.home;
+    }
     if ( relativePath.startsWith('/') ) {
         return relativePath;
     }


### PR DESCRIPTION
Running "cd" with no args should return the user to their home folder right? 

![image](https://github.com/HeyPuter/phoenix/assets/54413402/c1e332f0-ae08-4e62-809a-e64300b58176)

I think this change takes care of that 😊 should be noted that I'm not very used to JS so please make sure to test/review it from your side 😉