### PR TITLE
Make sleep builtin test more tolerant of minor variations

### DIFF
--- a/test/coreutils/sleep.js
+++ b/test/coreutils/sleep.js
@@ -85,8 +85,9 @@ export const runSleepTests = () => {
                     assert.fail(e);
                 }
                 const endTimeMs = performance.now();
-                const actualDurationMs = endTimeMs- startTimeMs;
-                assert.ok(actualDurationMs >= (durationS * 1000), `takes at least ${durationS} seconds`);
+                const actualDurationMs = endTimeMs - startTimeMs;
+                assert.ok(Math.abs(actualDurationMs - (durationS * 1000)) <= 10,
+                    `should pause for ${durationS} seconds, instead was ${actualDurationMs / 1000}`);
 
                 assert.equal(ctx.externs.out.output, '', 'sleep should not write to stdout');
                 assert.equal(ctx.externs.err.output, '', 'sleep should not write to stderr');


### PR DESCRIPTION
This was occasionally failing for me, and on CI. Instead of requiring that it's >= the requested duration, ensure it's within a few milliseconds. This allows for pauses that are very slightly less than requested, and also prevents them being massively too long. Report the expected and actual durations if it fails, for good measure.