### PR TITLE
Implement 'printf' utility

### DIFF
--- a/src/puter-shell/coreutils/__exports__.js
+++ b/src/puter-shell/coreutils/__exports__.js
@@ -39,6 +39,7 @@ import module_man from './man.js'
 import module_mkdir from './mkdir.js'
 import module_mv from './mv.js'
 import module_neofetch from './neofetch.js'
+import module_printf from './printf.js'
 import module_printhist from './printhist.js'
 import module_pwd from './pwd.js'
 import module_rm from './rm.js'
@@ -77,6 +78,7 @@ export default {
     "mkdir": module_mkdir,
     "mv": module_mv,
     "neofetch": module_neofetch,
+    "printf": module_printf,
     "printhist": module_printhist,
     "pwd": module_pwd,
     "rm": module_rm,

--- a/src/puter-shell/coreutils/printf.js
+++ b/src/puter-shell/coreutils/printf.js
@@ -1,0 +1,445 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Exit } from './coreutil_lib/exit.js';
+
+// TODO: get these values from a common place
+// DRY: Copied from echo_escapes.js
+const BEL = String.fromCharCode(7);
+const BS  = String.fromCharCode(8);
+const VT  = String.fromCharCode(0x0B);
+const FF  = String.fromCharCode(0x0C);
+
+function parseFormat(input, startOffset) {
+    let i = startOffset;
+
+    if (input[i] !== '%') {
+        throw new Error('Called parseFormat() without a format specifier!');
+    }
+    i++;
+
+    const result = {
+        flags: {
+            leftJustify: false,
+            prefixWithSign: false,
+            prefixWithSpaceIfWithoutSign: false,
+            alternativeForm: false,
+            padWithLeadingZeroes: false,
+        },
+        fieldWidth: null,
+        precision: null,
+        conversionSpecifier: null,
+
+        newOffset: startOffset,
+    };
+
+    // Output a single % for '%%' or '%' followed by the end of the input.
+    if (input[i] === '%') {
+        i++;
+        result.conversionSpecifier = '%';
+        result.newOffset = i;
+        return result;
+    }
+
+    const consumeInteger = () => {
+        const startIndex = i;
+        while (input[i] >= '0' && input[i] <= '9') {
+            i++;
+        }
+        if (startIndex === i) {
+            return null;
+        }
+
+        const integerString = input.substring(startIndex, i);
+        return Number.parseInt(integerString, 10);
+    };
+
+    // Flags
+    const possibleFlags = '-+ #0';
+    while (possibleFlags.includes(input[i])) {
+        switch (input[i]) {
+            case '-': result.flags.leftJustify = true; break;
+            case '+': result.flags.prefixWithSign = true; break;
+            case ' ': result.flags.prefixWithSpaceIfWithoutSign = true; break;
+            case '#': result.flags.alternativeForm = true; break;
+            case '0': result.flags.padWithLeadingZeroes = true; break;
+        }
+        i++;
+    }
+
+    // Field width
+    result.fieldWidth = consumeInteger();
+
+    // Precision
+    if (input[i] === '.') {
+        i++;
+        result.precision = consumeInteger() || 0;
+    }
+
+    // Conversion specifier
+    const possibleConversionSpecifiers = 'cdeEfFgGiousxX';
+    if (possibleConversionSpecifiers.includes(input[i])) {
+        result.conversionSpecifier = input[i];
+        i++;
+    } else {
+        throw new Error(`Invalid conversion specifier '${input.substring(startOffset, i + 1)}'`);
+    }
+
+    result.newOffset = i;
+    return result;
+}
+
+function formatOutput(parsedFormat, remainingArguments) {
+    const { flags, fieldWidth, precision, conversionSpecifier } = parsedFormat;
+
+    const padAndAlignString = (input) => {
+        if (!fieldWidth || input.length >= fieldWidth) {
+            return input;
+        }
+
+        const padding = ' '.repeat(fieldWidth - input.length);
+        return flags.leftJustify ? (input + padding) : (padding + input);
+    };
+
+    const formatInteger = (integer, specifier) => {
+        const unsigned = 'ouxX'.includes(specifier);
+        const radix = (() => {
+            switch (specifier) {
+                case 'o': return 8;
+                case 'x':
+                case 'X': return 16;
+                default: return 10;
+            }
+        })();
+
+        // POSIX doesn't specify what we should do to format a negative number as %u.
+        // Common behavior seems to be bit-casting it to unsigned.
+        if (unsigned && integer < 0) {
+            integer = integer >>> 0;
+        }
+
+        let digits = Math.abs(integer).toString(radix);
+        if (specifier === 'o' && flags.alternativeForm && digits[0] !== '0') {
+            // "For the o conversion specifier, it shall increase the precision to force the first digit of the result to be a zero."
+            // (Where 'it' is the alternative form flag.)
+            digits = '0' + digits;
+        }
+        const signOrPrefix = (() => {
+            if (flags.alternativeForm) {
+                if (specifier === 'x') return '0x';
+                if (specifier === 'X') return '0X';
+            }
+            if (unsigned) return '';
+            if (integer < 0) return '-';
+            if (flags.prefixWithSign) return '+';
+            if (flags.prefixWithSpaceIfWithoutSign) return ' ';
+            return '';
+        })();
+
+        // Expand digits with 0s, up to `precision` characters.
+        // "The default precision shall be 1."
+        const usedPrecision = precision ?? 1;
+        // Special case: "The result of converting a zero value with a precision of 0 shall be no characters."
+        if (usedPrecision === 0 && integer === 0) {
+            digits = '';
+        } else if (digits.length < precision) {
+            digits = '0'.repeat(precision - digits.length) + digits;
+        }
+
+        // Pad up to `fieldWidth` with spaces or 0s.
+        const width = signOrPrefix.length + digits.length;
+        let output = signOrPrefix + digits;
+        if (width < fieldWidth) {
+            if (flags.leftJustify) {
+                output = signOrPrefix + digits + ' '.repeat(fieldWidth - width);
+            } else if (precision === null && flags.padWithLeadingZeroes) {
+                // "For d, i , o, u, x, and X conversion specifiers, if a precision is specified, the '0' flag shall be ignored."
+                output = signOrPrefix + '0'.repeat(fieldWidth - width) + digits;
+            } else {
+                output = ' '.repeat(fieldWidth - width) + signOrPrefix + digits;
+            }
+        }
+
+        if (specifier === specifier.toUpperCase()) {
+            output = output.toUpperCase();
+        }
+
+        return output;
+    };
+
+    const formatFloat = (float, specifier) => {
+        if (float === undefined) float = 0;
+
+        const sign = (() => {
+            if (float < 0) return '-';
+            if (flags.prefixWithSign) return '+';
+            if (flags.prefixWithSpaceIfWithoutSign) return ' ';
+            return '';
+        })();
+        const floatString = (() => {
+            // NaN and Infinity are the same regardless of representation
+            if (!isFinite(float)) {
+                return float.toString();
+            }
+
+            const formatExponential = (mantissaString, exponent) => {
+                // #: "For [...] e, E, [...] conversion specifiers, the result shall always contain a radix character,
+                // even if no digits follow the radix character."
+                if (flags.alternativeForm && !mantissaString.includes('.')) {
+                    mantissaString += '.';
+                }
+
+                // "The exponent shall always contain at least two digits."
+                const exponentOutput = (() => {
+                    if (exponent <= -10 || exponent >= 10) return exponent.toString();
+                    if (exponent < 0) return '-0' + Math.abs(exponent).toString();
+                    return '+0' + Math.abs(exponent).toString();
+                })();
+                return mantissaString + 'e' + exponentOutput;
+            };
+
+            switch (specifier) {
+                // TODO: %a and %A, floats in hexadecimal
+                case 'e':
+                case 'E': {
+                    // "When the precision is missing, six digits shall be written after the radix character"
+                    const usedPrecision = precision ?? 6;
+                    // We unfortunately can't fully rely on toExponential() because printf has different formatting rules.
+                    const [mantissaString, exponentString] = Math.abs(float).toExponential(usedPrecision).split('e');
+                    const exponent = Number.parseInt(exponentString);
+                    return formatExponential(mantissaString, exponent);
+                }
+                case 'f':
+                case 'F': {
+                    // "If the precision is omitted from the argument, six digits shall be written after the radix character"
+                    const usedPrecision = precision ?? 6;
+                    const result = Math.abs(float).toFixed(usedPrecision);
+                    if (flags.alternativeForm && usedPrecision === 0) {
+                        // #: "For [...] f, F, [...] conversion specifiers, the result shall always contain a radix character,
+                        // even if no digits follow the radix character."
+                        return result + '.';
+                    }
+                    return result;
+                }
+                case 'g':
+                case 'G': {
+                    // Default isn't specified in the spec, but 6 matches behavior of other implementations.
+                    const usedPrecision = precision ?? 6;
+
+                    // "The style used depends on the value converted: style e (or E) shall be used only if the exponent
+                    // resulting from the conversion is less than -4 or greater than or equal to the precision."
+                    // We add a digit of precision to make sure we don't break things when rounding later.
+                    const [mantissaString, exponentString] = Math.abs(float).toExponential(usedPrecision + 1).split('e');
+                    const mantissa = Number.parseFloat(mantissaString);
+                    const exponent = Number.parseInt(exponentString);
+
+                    // Unfortunately, `float.toPrecision()` doesn't use the same rules as printf to decide whether to
+                    // use decimal or exponential representation, so we have to construct the output ourselves.
+                    const usingExponential = exponent > usedPrecision || exponent < -4;
+                    if (usingExponential) {
+                        const decimalDigits = Math.max(0, usedPrecision - (mantissa < 1 ? 0 : 1));
+                        // "Trailing zeros are removed from the result."
+                        let mantissaOutput = mantissa.toFixed(decimalDigits)
+                           .replace(/\.0+/, '');
+                        return formatExponential(mantissaOutput, exponent);
+                    }
+
+                    // Decimal representation
+                    const result = Math.abs(float).toPrecision(usedPrecision);
+                    if (flags.alternativeForm && usedPrecision === 0) {
+                        // #: "For [...] g, and G conversion specifiers, the result shall always contain a radix character,
+                        // even if no digits follow the radix character."
+                        return result + '.';
+                    }
+                    // Trailing zeros are removed from the result.
+                    return result.replace(/\.0+/, '');
+                }
+                default: throw new Error(`Invalid float specifier '${specifier}'`);
+            }
+        })();
+
+        // Pad up to `fieldWidth` with spaces or 0s.
+        const width = sign.length + floatString.length;
+        let output = sign + floatString;
+        if (width < fieldWidth) {
+            if (flags.leftJustify) {
+                output = sign + floatString + ' '.repeat(fieldWidth - width);
+            } else if (flags.padWithLeadingZeroes && isFinite(float)) {
+                output = sign + '0'.repeat(fieldWidth - width) + floatString;
+            } else {
+                output = ' '.repeat(fieldWidth - width) + sign + floatString;
+            }
+        }
+
+        if (specifier === specifier.toUpperCase()) {
+            output = output.toUpperCase();
+        } else {
+            output = output.toLowerCase();
+        }
+
+        return output;
+    };
+
+    switch (conversionSpecifier) {
+        // TODO: a,A: Float in hexadecimal format
+        // TODO: b: binary data with escapes
+        // TODO: Any other common options that are not in the posix spec
+
+        // Integers
+        case 'd':
+        case 'i':
+        case 'o':
+        case 'u':
+        case 'x':
+        case 'X': {
+            return formatInteger(Number.parseInt(remainingArguments.shift()) || 0, conversionSpecifier);
+        }
+
+        // Floating point numbers
+        case 'e':
+        case 'E':
+        case 'f':
+        case 'F':
+        case 'g':
+        case 'G': {
+            return formatFloat(Number.parseFloat(remainingArguments.shift()), conversionSpecifier);
+        }
+
+        // Single character
+        case 'c': {
+            const argument = remainingArguments.shift() || '';
+            // It's unspecified whether an empty string produces a null byte or nothing.
+            // We'll go with nothing for now.
+            return padAndAlignString(argument[0] || '');
+        }
+
+        // String
+        case 's': {
+            let argument = remainingArguments.shift() || '';
+            if (precision && precision < argument.length) {
+                argument = argument.substring(0, precision);
+            }
+            return padAndAlignString(argument);
+        }
+
+        // Percent sign
+        case '%': return '%';
+    }
+}
+
+// https://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html
+export default {
+    name: 'printf',
+    usage: 'printf FORMAT [ARGUMENT...]',
+    description: 'Write a formatted string.',
+    args: {
+        $: 'simple-parser',
+        allowPositionals: true
+    },
+    execute: async ctx => {
+        const { out, err } = ctx.externs;
+        const { positionals } = ctx.locals;
+        const [ format, ...remainingArguments ] = ctx.locals.positionals;
+
+        if (positionals.length === 0) {
+            await err.write('printf: Missing format argument\n');
+            throw new Exit(1);
+        }
+
+        // We process the format as many times as needed to consume all of remainingArguments, but always at least once.
+        do {
+            const previousRemainingArgumentCount = remainingArguments.length;
+            let output = '';
+
+            for (let i = 0; i < format.length; ++i) {
+                let char = format[i];
+                // Escape sequences
+                if (char === '\\') {
+                    char = format[++i];
+                    switch (char) {
+                        case undefined: {
+                            // We reached the end of the string, just output the slash.
+                            output += '\\';
+                            break;
+                        }
+                        case '\\': output += '\\'; break;
+                        case 'a': output += BEL; break;
+                        case 'b': output += BS; break;
+                        case 'f': output += FF; break;
+                        case 'n': output += '\n'; break;
+                        case 'r': output += '\r'; break;
+                        case 't': output += '\t'; break;
+                        case 'v': output += VT; break;
+                        default: {
+                            // 1 to 3-digit octal number
+                            if (char >= '0' && char <= '9') {
+                                const digitsStartI = i;
+                                if (format[i+1] >= '0' && format[i+1] <= '9') {
+                                    i++;
+                                    if (format[i+1] >= '0' && format[i+1] <= '9') {
+                                        i++;
+                                    }
+                                }
+
+                                const octalString = format.substring(digitsStartI, i + 1);
+                                const octalValue = Number.parseInt(octalString, 8);
+                                output += String.fromCodePoint(octalValue);
+                                break;
+                            }
+
+                            // Unrecognized, so just output the sequence verbatim.
+                            output += '\\' + char;
+                            break;
+                        }
+                    }
+                    continue;
+                }
+
+                // Conversion specifiers
+                if (char === '%') {
+                    // Parse the conversion specifier
+                    let parsedFormat;
+                    try {
+                        parsedFormat = parseFormat(format, i);
+                    } catch (e) {
+                        await err.write(`printf: ${e.message}\n`);
+                        throw new Exit(1);
+                    }
+                    i = parsedFormat.newOffset - 1; // -1 because we're about to increment i in the loop header
+
+                    // Output the result
+                    output += formatOutput(parsedFormat, remainingArguments);
+                    continue;
+                }
+
+                // Everything else is copied directly.
+                // TODO: Append these to the output in batches, for performance?
+                output += char;
+            }
+
+            await out.write(output);
+
+            // "If the format operand contains no conversion specifications and argument operands are present, the results are unspecified."
+            // We handle this by printing it once and stopping.
+            if (remainingArguments.length === previousRemainingArgumentCount) {
+                break;
+            }
+        } while (remainingArguments.length > 0);
+
+    }
+};

--- a/test/coreutils.test.js
+++ b/test/coreutils.test.js
@@ -22,6 +22,7 @@ import { runEchoTests } from "./coreutils/echo.js";
 import { runEnvTests } from "./coreutils/env.js";
 import { runFalseTests } from "./coreutils/false.js";
 import { runHeadTests } from "./coreutils/head.js";
+import { runPrintfTests } from './coreutils/printf.js';
 import { runSleepTests } from "./coreutils/sleep.js";
 import { runSortTests } from "./coreutils/sort.js";
 import { runTailTests } from "./coreutils/tail.js";
@@ -35,6 +36,7 @@ describe('coreutils', function () {
     runEnvTests();
     runFalseTests();
     runHeadTests();
+    runPrintfTests();
     runSleepTests();
     runSortTests();
     runTailTests();

--- a/test/coreutils/printf.js
+++ b/test/coreutils/printf.js
@@ -1,0 +1,587 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import assert from 'assert';
+import { MakeTestContext } from './harness.js'
+import builtins from '../../src/puter-shell/coreutils/__exports__.js';
+
+export const runPrintfTests = () => {
+    describe('printf', function () {
+        const testCases = [
+            {
+                description: 'outputs format verbatim if no operands were given',
+                input: [ 'hello' ],
+                expectedStdout: 'hello',
+                expectedStderr: '',
+            },
+            {
+                description: 'outputs octal escape sequences',
+                input: [ '\\0\\41\\041' ],
+                expectedStdout: '\0!!',
+                expectedStderr: '',
+            },
+            {
+                description: 'outputs a trailing backslash as itself',
+                input: [ '\\' ],
+                expectedStdout: '\\',
+                expectedStderr: '',
+            },
+            {
+                description: 'outputs unrecognized escape sequences as themselves',
+                input: [ '\\z\\@\\#' ],
+                expectedStdout: '\\z\\@\\#',
+                expectedStderr: '',
+            },
+            {
+                description: 'outputs escape sequences',
+                input: [ '\\a\\b\\f\\n\\r\\t\\v' ],
+                expectedStdout: '\x07\x08\x0C\n\r\t\x0B',
+                expectedStderr: '',
+            },
+            {
+                description: 'rejects empty format specifier',
+                input: [ '%' ],
+                expectedStdout: '',
+                expectedStderr: 'printf: Invalid conversion specifier \'%\'\n',
+                expectedFail: true,
+            },
+            {
+                description: 'outputs `%%` as `%`',
+                input: [ '%%' ],
+                expectedStdout: '%',
+                expectedStderr: '',
+            },
+
+            //
+            // %c: Character
+            //
+            {
+                description: 'outputs single characters for `%c`',
+                input: [ '%c', 'hello', '123' ],
+                expectedStdout: 'h1',
+                expectedStderr: '',
+            },
+            {
+                description: 'outputs single characters for `%c`',
+                input: [ '%c', 'hello', '123' ],
+                expectedStdout: 'h1',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports padding and alignment for `%c`',
+                input: [ '"%-12c" "%12c"', 'hello', '123' ],
+                expectedStdout: '"h           " "           1"',
+                expectedStderr: '',
+            },
+
+            //
+            // %s: String
+            //
+            {
+                description: 'outputs whole value as string for `%s`',
+                input: [ '%s', 'hello', '123' ],
+                expectedStdout: 'hello123',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports padding and alignment for `%s`',
+                input: [ '"%-12s" "%12s"', 'hello', '123' ],
+                expectedStdout: '"hello       " "         123"',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports precision for `%s`',
+                input: [ '%.4s\n', 'hello', '123' ],
+                expectedStdout: 'hell\n123\n',
+                expectedStderr: '',
+            },
+
+            //
+            // %d and %i: Signed decimal integer
+            //
+            {
+                description: 'outputs a signed decimal integer for `%d` or `%i`',
+                input: [ '%d %i\n', '13', '13', '-127', '-127' ],
+                expectedStdout: '13 13\n-127 -127\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports padding for `%d` and `%i`',
+                input: [ '"%5d" "%05i"\n', '13', '13', '-127', '-127' ],
+                expectedStdout: '"   13" "00013"\n" -127" "-0127"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports alignment for `%d` and `%i`',
+                input: [ '"%-5d" "%0-5i"\n', '13', '13', '-127', '-127' ],
+                expectedStdout: '"13   " "13   "\n"-127 " "-127 "\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports `+` flag for `%d` and `%i`',
+                input: [ '"%+5d" "%+05i"\n', '13', '13', '-127', '-127' ],
+                expectedStdout: '"  +13" "+0013"\n" -127" "-0127"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports `+` flag with alignment for `%d` and `%i`',
+                input: [ '"%+-5d" "%+-05i"\n', '13', '13', '-127', '-127' ],
+                expectedStdout: '"+13  " "+13  "\n"-127 " "-127 "\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports ` ` flag for `%d` and `%i`',
+                input: [ '"% 5d" "% 05i"\n', '13', '13', '-127', '-127' ],
+                expectedStdout: '"   13" " 0013"\n" -127" "-0127"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports ` ` flag with alignment for `%d` and `%i`',
+                input: [ '"% -5d" "% -05i"\n', '13', '13', '-127', '-127' ],
+                expectedStdout: '" 13  " " 13  "\n"-127 " "-127 "\n',
+                expectedStderr: '',
+            },
+            {
+                description: '`+` flag overrides ` ` for `%d` and `%i`',
+                input: [ '"%+ -5d" "%+ 05i"\n', '13', '13', '-127', '-127' ],
+                expectedStdout: '"+13  " "+0013"\n"-127 " "-0127"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports precision for `%d` and `%i`',
+                input: [ '"%.5d" "%0.5i"\n', '13', '13', '-127', '-127' ],
+                expectedStdout: '"00013" "00013"\n"-00127" "-00127"\n',
+                expectedStderr: '',
+            },
+            {
+                description: '0 precision for `%d` and `%i`',
+                input: [ '"%.d" "%.0i"\n', '13', '13', '-127', '-127', '0', '0' ],
+                expectedStdout: '"13" "13"\n"-127" "-127"\n"" ""\n',
+                expectedStderr: '',
+            },
+
+            //
+            // %u: Unsigned decimal integer
+            //
+            {
+                description: 'outputs an unsigned decimal integer for `%u`',
+                input: [ '%u\n', '13', '0', '-127' ],
+                expectedStdout: '13\n0\n4294967169\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports padding for `%u`',
+                input: [ '"%5u" "%05u"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"   13" "00013"\n"    0" "00000"\n"4294967169" "4294967169"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports alignment for `%u`',
+                input: [ '"%-5u" "%0-5u"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"13   " "13   "\n"0    " "0    "\n"4294967169" "4294967169"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports precision for `%u`',
+                input: [ '"%.5u" "%0.5u"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"00013" "00013"\n"00000" "00000"\n"4294967169" "4294967169"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'ignores `+` and ` ` flags for `%u`',
+                input: [ '"%+u" "% u"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"13" "13"\n"0" "0"\n"4294967169" "4294967169"\n',
+                expectedStderr: '',
+            },
+            {
+                description: '0 precision for `%u`',
+                input: [ '"%.u" "%.0u"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"13" "13"\n"" ""\n"4294967169" "4294967169"\n',
+                expectedStderr: '',
+            },
+
+            //
+            // %o: Unsigned octal integer
+            //
+            {
+                description: 'outputs an unsigned octal integer for `%o`',
+                input: [ '%o\n', '13', '0', '-127' ],
+                expectedStdout: '15\n0\n37777777601\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports padding for `%o`',
+                input: [ '"%5o" "%05o"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"   15" "00015"\n"    0" "00000"\n"37777777601" "37777777601"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports alignment for `%o`',
+                input: [ '"%-5o" "%0-5o"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"15   " "15   "\n"0    " "0    "\n"37777777601" "37777777601"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports precision for `%o`',
+                input: [ '"%.5o" "%0.5o"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"00015" "00015"\n"00000" "00000"\n"37777777601" "37777777601"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'ignores `+` and ` ` flags for `%o`',
+                input: [ '"%+o" "% o"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"15" "15"\n"0" "0"\n"37777777601" "37777777601"\n',
+                expectedStderr: '',
+            },
+            {
+                description: '0 precision for `%o`',
+                input: [ '"%.o" "%.0o"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"15" "15"\n"" ""\n"37777777601" "37777777601"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'ensures a starting `0` when using the `#` flag for `%o`',
+                input: [ '"%#o" "%#0o"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"015" "015"\n"0" "0"\n"037777777601" "037777777601"\n',
+                expectedStderr: '',
+            },
+
+            //
+            // %x and %X: Unsigned hexadecimal integer
+            //
+            {
+                description: 'outputs an unsigned hexadecimal integer for `%x` and `%X`',
+                input: [ '"%x" "%X"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"d" "D"\n"0" "0"\n"ffffff81" "FFFFFF81"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports padding for `%x` and `%X`',
+                input: [ '"%5x" "%05X"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"    d" "0000D"\n"    0" "00000"\n"ffffff81" "FFFFFF81"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports alignment for `%x` and `%X`',
+                input: [ '"%-5x" "%0-5X"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"d    " "D    "\n"0    " "0    "\n"ffffff81" "FFFFFF81"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports precision for `%x` and `%X`',
+                input: [ '"%.5x" "%0.5X"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"0000d" "0000D"\n"00000" "00000"\n"ffffff81" "FFFFFF81"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'ignores `+` and ` ` flags for `%x` and `%X`',
+                input: [ '"%+x" "% X"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"d" "D"\n"0" "0"\n"ffffff81" "FFFFFF81"\n',
+                expectedStderr: '',
+            },
+            {
+                description: '0 precision for `%x` and `%X`',
+                input: [ '"%.x" "%.0X"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"d" "D"\n"" ""\n"ffffff81" "FFFFFF81"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'ensures a starting `0x` or `0X` when using the `#` flag for `%x` and `%X`',
+                input: [ '"%#x" "%#0X"\n', '13', '13', '0', '0', '-127', '-127' ],
+                expectedStdout: '"0xd" "0XD"\n"0x0" "0X0"\n"0xffffff81" "0XFFFFFF81"\n',
+                expectedStderr: '',
+            },
+
+            //
+            // %f and %F: Floating point, decimal notation
+            //
+            {
+                description: 'outputs a floating point number in decimal notation for `%f` and `%F`',
+                input: [ '"%f" "%F"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"13.000000" "13.000000"\n"-12345.678900" "-12345.678900"\n"0.000010" "0.000010"\n"infinity" "INFINITY"\n"nan" "NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports padding for `%f` and `%F`',
+                input: [ '"%12f" "%012F"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"   13.000000" "00013.000000"\n"-12345.678900" "-12345.678900"\n"    0.000010" "00000.000010"\n' +
+                    '"    infinity" "    INFINITY"\n"         nan" "         NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports padding and alignment for `%f` and `%F`',
+                input: [ '"%-12f" "%-012F"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"13.000000   " "13.000000   "\n"-12345.678900" "-12345.678900"\n"0.000010    " "0.000010    "\n' +
+                    '"infinity    " "INFINITY    "\n"nan         " "NAN         "\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports `+` flag for `%f` and `%F`',
+                input: [ '"%+12f" "%+012F"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"  +13.000000" "+0013.000000"\n"-12345.678900" "-12345.678900"\n"   +0.000010" "+0000.000010"\n' +
+                    '"   +infinity" "   +INFINITY"\n"        +nan" "        +NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports `+` flag with alignment for `%f` and `%F`',
+                input: [ '"%+-12f" "%+-012F"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"+13.000000  " "+13.000000  "\n"-12345.678900" "-12345.678900"\n"+0.000010   " "+0.000010   "\n' +
+                    '"+infinity   " "+INFINITY   "\n"+nan        " "+NAN        "\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports ` ` flag for `%f` and `%F`',
+                input: [ '"% 12f" "% 012F"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"   13.000000" " 0013.000000"\n"-12345.678900" "-12345.678900"\n"    0.000010" " 0000.000010"\n' +
+                    '"    infinity" "    INFINITY"\n"         nan" "         NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports ` ` flag with alignment for `%f` and `%F`',
+                input: [ '"% -12f" "% -012F"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '" 13.000000  " " 13.000000  "\n"-12345.678900" "-12345.678900"\n" 0.000010   " " 0.000010   "\n' +
+                    '" infinity   " " INFINITY   "\n" nan        " " NAN        "\n',
+                expectedStderr: '',
+            },
+            {
+                description: '`+` flag overrides ` ` for `%f` and `%F`',
+                input: [ '"% +12f" "% +012F"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"  +13.000000" "+0013.000000"\n"-12345.678900" "-12345.678900"\n"   +0.000010" "+0000.000010"\n' +
+                    '"   +infinity" "   +INFINITY"\n"        +nan" "        +NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports precision for `%f` and `%F`',
+                input: [ '"%.3f" "%0.3F"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"13.000" "13.000"\n"-12345.679" "-12345.679"\n"0.000" "0.000"\n"infinity" "INFINITY"\n"nan" "NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'zero precision removes decimal point for `%f` and `%F`',
+                input: [ '"%.0f" "%0.0F"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"13" "13"\n"-12346" "-12346"\n"0" "0"\n"infinity" "INFINITY"\n"nan" "NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'zero precision with `#` flag forces a decimal point for `%f` and `%F`',
+                input: [ '"%#.0f" "%0#.0F"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"13." "13."\n"-12346." "-12346."\n"0." "0."\n"infinity" "INFINITY"\n"nan" "NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports width and precision for `%f` and `%F`',
+                input: [ '"%12.3f" "%012.3F"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"      13.000" "00000013.000"\n"  -12345.679" "-0012345.679"\n"       0.000" "00000000.000"\n' +
+                    '"    infinity" "    INFINITY"\n"         nan" "         NAN"\n',
+                expectedStderr: '',
+            },
+
+            //
+            // %e and %E: Floating point, exponential notation
+            //
+            {
+                description: 'outputs a floating point number in exponential notation for `%e` and `%E`',
+                input: [ '"%e" "%E"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"1.300000e+01" "1.300000E+01"\n"-1.234568e+04" "-1.234568E+04"\n"1.000000e-05" "1.000000E-05"\n' +
+                    '"infinity" "INFINITY"\n"nan" "NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports padding for `%e` and `%E`',
+                input: [ '"%15e" "%015E"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"   1.300000e+01" "0001.300000E+01"\n"  -1.234568e+04" "-001.234568E+04"\n"   1.000000e-05" "0001.000000E-05"\n' +
+                    '"       infinity" "       INFINITY"\n"            nan" "            NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports padding and alignment for `%e` and `%E`',
+                input: [ '"%-15e" "%-015E"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"1.300000e+01   " "1.300000E+01   "\n"-1.234568e+04  " "-1.234568E+04  "\n"1.000000e-05   " "1.000000E-05   "\n' +
+                    '"infinity       " "INFINITY       "\n"nan            " "NAN            "\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports `+` flag for `%e` and `%E`',
+                input: [ '"%+15e" "%+015E"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"  +1.300000e+01" "+001.300000E+01"\n"  -1.234568e+04" "-001.234568E+04"\n"  +1.000000e-05" "+001.000000E-05"\n' +
+                    '"      +infinity" "      +INFINITY"\n"           +nan" "           +NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports `+` flag with alignment for `%e` and `%E`',
+                input: [ '"%+-15e" "%+-015E"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"+1.300000e+01  " "+1.300000E+01  "\n"-1.234568e+04  " "-1.234568E+04  "\n"+1.000000e-05  " "+1.000000E-05  "\n' +
+                    '"+infinity      " "+INFINITY      "\n"+nan           " "+NAN           "\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports ` ` flag for `%e` and `%E`',
+                input: [ '"% 15e" "% 015E"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"   1.300000e+01" " 001.300000E+01"\n"  -1.234568e+04" "-001.234568E+04"\n"   1.000000e-05" " 001.000000E-05"\n' +
+                    '"       infinity" "       INFINITY"\n"            nan" "            NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports ` ` flag with alignment for `%e` and `%E`',
+                input: [ '"% -15e" "% -015E"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '" 1.300000e+01  " " 1.300000E+01  "\n"-1.234568e+04  " "-1.234568E+04  "\n" 1.000000e-05  " " 1.000000E-05  "\n' +
+                    '" infinity      " " INFINITY      "\n" nan           " " NAN           "\n',
+                expectedStderr: '',
+            },
+            {
+                description: '`+` flag overrides ` ` for `%e` and `%E`',
+                input: [ '"% +15e" "% +015E"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"  +1.300000e+01" "+001.300000E+01"\n"  -1.234568e+04" "-001.234568E+04"\n"  +1.000000e-05" "+001.000000E-05"\n' +
+                    '"      +infinity" "      +INFINITY"\n"           +nan" "           +NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports precision for `%e` and `%E`',
+                input: [ '"%.3e" "%0.3E"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"1.300e+01" "1.300E+01"\n"-1.235e+04" "-1.235E+04"\n"1.000e-05" "1.000E-05"\n"infinity" "INFINITY"\n"nan" "NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'zero precision removes decimal point for `%e` and `%E`',
+                input: [ '"%.0e" "%0.0E"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"1e+01" "1E+01"\n"-1e+04" "-1E+04"\n"1e-05" "1E-05"\n"infinity" "INFINITY"\n"nan" "NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'zero precision with `#` flag forces a decimal point for `%e` and `%E`',
+                input: [ '"%#.0e" "%0#.0E"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"1.e+01" "1.E+01"\n"-1.e+04" "-1.E+04"\n"1.e-05" "1.E-05"\n"infinity" "INFINITY"\n"nan" "NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports width and precision for `%e` and `%E`',
+                input: [ '"%15.3e" "%015.3E"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"      1.300e+01" "0000001.300E+01"\n"     -1.235e+04" "-000001.235E+04"\n"      1.000e-05" "0000001.000E-05"\n' +
+                    '"       infinity" "       INFINITY"\n"            nan" "            NAN"\n',
+                expectedStderr: '',
+            },
+
+            //
+            // %g and %G: Floating point, set number of significant digits, may be decimal or exponential notation
+            //
+            {
+                description: 'outputs a floating point number for `%g` and `%G`',
+                input: [ '"%g" "%G"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"13" "13"\n"-12345.7" "-12345.7"\n"1e-05" "1E-05"\n"infinity" "INFINITY"\n"nan" "NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports padding for `%g` and `%G`',
+                input: [ '"%12g" "%012G"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"          13" "000000000013"\n"    -12345.7" "-000012345.7"\n"       1e-05" "00000001E-05"\n' +
+                    '"    infinity" "    INFINITY"\n"         nan" "         NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports padding and alignment for `%g` and `%G`',
+                input: [ '"%-12g" "%-012G"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"13          " "13          "\n"-12345.7    " "-12345.7    "\n"1e-05       " "1E-05       "\n' +
+                    '"infinity    " "INFINITY    "\n"nan         " "NAN         "\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports `+` flag for `%g` and `%G`',
+                input: [ '"%+12g" "%+012G"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"         +13" "+00000000013"\n"    -12345.7" "-000012345.7"\n"      +1e-05" "+0000001E-05"\n' +
+                    '"   +infinity" "   +INFINITY"\n"        +nan" "        +NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports `+` flag with alignment for `%g` and `%G`',
+                input: [ '"%+-12g" "%+-012G"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"+13         " "+13         "\n"-12345.7    " "-12345.7    "\n"+1e-05      " "+1E-05      "\n' +
+                    '"+infinity   " "+INFINITY   "\n"+nan        " "+NAN        "\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports ` ` flag for `%g` and `%G`',
+                input: [ '"% 12g" "% 012G"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"          13" " 00000000013"\n"    -12345.7" "-000012345.7"\n"       1e-05" " 0000001E-05"\n' +
+                    '"    infinity" "    INFINITY"\n"         nan" "         NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports ` ` flag with alignment for `%g` and `%G`',
+                input: [ '"% -12g" "% -012G"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '" 13         " " 13         "\n"-12345.7    " "-12345.7    "\n" 1e-05      " " 1E-05      "\n' +
+                    '" infinity   " " INFINITY   "\n" nan        " " NAN        "\n',
+                expectedStderr: '',
+            },
+            {
+                description: '`+` flag overrides ` ` for `%g` and `%G`',
+                input: [ '"% +12g" "% +012G"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"         +13" "+00000000013"\n"    -12345.7" "-000012345.7"\n"      +1e-05" "+0000001E-05"\n' +
+                    '"   +infinity" "   +INFINITY"\n"        +nan" "        +NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports precision for `%g` and `%G`',
+                input: [ '"%.3g" "%0.3G"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"13" "13"\n"-1.23e+04" "-1.23E+04"\n"1e-05" "1E-05"\n"infinity" "INFINITY"\n"nan" "NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'zero precision removes decimal point for `%g` and `%G`',
+                input: [ '"%.0g" "%0.0G"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"1e+01" "1E+01"\n"-1e+04" "-1E+04"\n"1e-05" "1E-05"\n"infinity" "INFINITY"\n"nan" "NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'zero precision with `#` flag forces a decimal point for `%g` and `%G`',
+                input: [ '"%#.0g" "%0#.0G"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"1.e+01" "1.E+01"\n"-1.e+04" "-1.E+04"\n"1.e-05" "1.E-05"\n"infinity" "INFINITY"\n"nan" "NAN"\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'supports width and precision for `%g` and `%G`',
+                input: [ '"%12.3g" "%012.3G"\n', '13', '13', '-12345.67890', '-12345.67890', '0.00001', '0.00001', 'Infinity', 'Infinity', 'NaN', 'NaN' ],
+                expectedStdout: '"          13" "000000000013"\n"   -1.23e+04" "-0001.23E+04"\n"       1e-05" "00000001E-05"\n' +
+                    '"    infinity" "    INFINITY"\n"         nan" "         NAN"\n',
+                expectedStderr: '',
+            },
+        ];
+
+        for (const { description, input, expectedStdout, expectedStderr, expectedFail } of testCases) {
+            it(description, async () => {
+                let ctx = MakeTestContext(builtins.printf, { positionals: input });
+                let hadError = false;
+                try {
+                    const result = await builtins.printf.execute(ctx);
+                    if (!expectedFail) {
+                        assert.equal(result, undefined, 'should exit successfully, returning nothing');
+                    }
+                } catch (e) {
+                    hadError = true;
+                    if (!expectedFail) {
+                        assert.fail(e);
+                    }
+                }
+                if (expectedFail && !hadError) {
+                    assert.fail('should have returned an error code');
+                }
+                assert.equal(ctx.externs.out.output, expectedStdout, 'wrong output written to stdout');
+                assert.equal(ctx.externs.err.output, expectedStderr, 'wrong output written to stderr');
+            });
+        }
+    });
+};


### PR DESCRIPTION
This is by no means complete, but covers most of the POSIX spec: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html

- Escape sequences (currently the shell handles these wrong, see https://github.com/HeyPuter/phoenix/issues/53 )
- %d %i %o %u %x and %X integer formatters
- %e %E %f %F %g and %G float formatters
- %c and %S string formatters

Still to do:
- %a and %A hexadecimal float formatters
- %b for formatting a string including escape sequences
- Anything beyond the spec that's common and users might expect.