### PR TITLE
date: Add some basic tests, and fix a bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "dependencies": {
         "@pkgjs/parseargs": "^0.11.0",
         "capture-console": "^1.0.2",
+        "chronokinesis": "^6.0.0",
         "cli-columns": "^4.0.0",
         "columnify": "^1.6.0",
         "fs-mode-to-string": "^0.0.2",
@@ -516,6 +517,11 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/chronokinesis": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/chronokinesis/-/chronokinesis-6.0.0.tgz",
+      "integrity": "sha512-NxGxNuzROLws2VVvSj9r1qrq0JK0AwR44FNk+sGfPZlG5EW3viz6z2elg6ZwE2YFCn6+Qg3sPqkfIYLyZ0wAtQ=="
     },
     "node_modules/cli-columns": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@pkgjs/parseargs": "^0.11.0",
     "capture-console": "^1.0.2",
+    "chronokinesis": "^6.0.0",
     "cli-columns": "^4.0.0",
     "columnify": "^1.6.0",
     "fs-mode-to-string": "^0.0.2",

--- a/src/puter-shell/coreutils/date.js
+++ b/src/puter-shell/coreutils/date.js
@@ -77,10 +77,18 @@ export default {
     args: {
         $: 'simple-parser',
         allowPositionals: true,
+        options: {
+            utc: {
+                description: 'Operate in UTC instead of the local timezone',
+                type: 'boolean',
+                short: 'u',
+                default: false,
+            }
+        }
     },
     execute: async ctx => {
         const { out, err } = ctx.externs;
-        const { positionals } = ctx.locals;
+        const { positionals, values } = ctx.locals;
 
         if ( positionals.length > 1 ) {
             await err.write('date: Too many arguments\n');
@@ -98,6 +106,7 @@ export default {
         // TODO: Should we use the server time instead? Maybe put that behind an option.
         const date = new Date();
         const locale = 'en-US'; // TODO: POSIX: Pull this from the user's settings.
+        const timeZone = values.utc ? 'UTC' : undefined;
 
         let output = '';
         for (let i = 0; i < format.length; i++) {
@@ -107,13 +116,13 @@ export default {
                 switch (char) {
                     // "Locale's abbreviated weekday name."
                     case 'a': {
-                        output += date.toLocaleDateString(locale, { weekday: 'short' });
+                        output += date.toLocaleDateString(locale, { timeZone: timeZone, weekday: 'short' });
                         break;
                     }
 
                     // "Locale's full weekday name."
                     case 'A': {
-                        output += date.toLocaleDateString(locale, { weekday: 'long' });
+                        output += date.toLocaleDateString(locale, { timeZone: timeZone, weekday: 'long' });
                         break;
                     }
 
@@ -121,19 +130,19 @@ export default {
                     case 'b':
                     // "A synonym for %b."
                     case 'h': {
-                        output += date.toLocaleDateString(locale, { month: 'short' });
+                        output += date.toLocaleDateString(locale, { timeZone: timeZone, month: 'short' });
                         break;
                     }
 
                     // "Locale's full month name."
                     case 'B': {
-                        output += date.toLocaleDateString(locale, { month: 'long' });
+                        output += date.toLocaleDateString(locale, { timeZone: timeZone, month: 'long' });
                         break;
                     }
 
                     // "Locale's appropriate date and time representation."
                     case 'c':  {
-                        output += date.toLocaleString(locale);
+                        output += date.toLocaleString(locale, { timeZone: timeZone });
                         break;
                     }
 
@@ -263,13 +272,13 @@ export default {
 
                     // "Locale's appropriate date representation."
                     case 'x': {
-                        output += date.toLocaleDateString(locale);
+                        output += date.toLocaleDateString(locale, { timeZone: timeZone });
                         break;
                     }
 
                     // "Locale's appropriate time representation."
                     case 'X': {
-                        output += date.toLocaleTimeString(locale);
+                        output += date.toLocaleTimeString(locale, { timeZone: timeZone });
                         break;
                     }
 
@@ -287,7 +296,7 @@ export default {
 
                     // "Timezone name, or no characters if no timezone is determinable."
                     case 'Z': {
-                        output += date.toLocaleDateString(locale, { timeZoneName: 'short' });
+                        output += date.toLocaleDateString(locale, { timeZone: timeZone, timeZoneName: 'short' });
                         break;
                     }
 

--- a/src/puter-shell/coreutils/date.js
+++ b/src/puter-shell/coreutils/date.js
@@ -296,7 +296,8 @@ export default {
 
                     // "Timezone name, or no characters if no timezone is determinable."
                     case 'Z': {
-                        output += date.toLocaleDateString(locale, { timeZone: timeZone, timeZoneName: 'short' });
+                        const parts = new Intl.DateTimeFormat(locale, { timeZone: timeZone, timeZoneName: 'short' }).formatToParts(date);
+                        output += parts.find(it => it.type === 'timeZoneName').value;
                         break;
                     }
 

--- a/test/coreutils.test.js
+++ b/test/coreutils.test.js
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { runBasenameTests } from "./coreutils/basename.js";
+import { runDateTests } from "./coreutils/date.js";
 import { runDirnameTests } from "./coreutils/dirname.js";
 import { runEchoTests } from "./coreutils/echo.js";
 import { runEnvTests } from "./coreutils/env.js";
@@ -32,6 +33,7 @@ import { runWcTests } from "./coreutils/wc.js";
 
 describe('coreutils', function () {
     runBasenameTests();
+    runDateTests();
     runDirnameTests();
     runEchoTests();
     runEnvTests();

--- a/test/coreutils/date.js
+++ b/test/coreutils/date.js
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2024  Puter Technologies Inc.
+ *
+ * This file is part of Phoenix Shell.
+ *
+ * Phoenix Shell is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import assert from 'assert';
+import * as ck from 'chronokinesis';
+import { MakeTestContext } from './harness.js'
+import builtins from '../../src/puter-shell/coreutils/__exports__.js';
+
+export const runDateTests = () => {
+    describe('date', function () {
+        beforeEach(() => {
+            ck.freeze();
+            ck.timezone('UTC', '2024-03-07 13:05:07');
+        });
+        afterEach(() => {
+            ck.reset();
+        });
+
+        const testCases = [
+            {
+                description: 'outputs the date and time in a standard format when no format parameter is given',
+                input: [ ],
+                options: { utc: true },
+                expectedStdout: 'Thu Mar  7 13:05:07 UTC 2024\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'outputs the format verbatim if no format sequences are included',
+                input: [ '+hello' ],
+                options: { utc: true },
+                expectedStdout: 'hello\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%a outputs abbreviated weekday name',
+                input: [ '+%a' ],
+                options: { utc: true },
+                expectedStdout: 'Thu\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%A outputs full weekday name',
+                input: [ '+%A' ],
+                options: { utc: true },
+                expectedStdout: 'Thursday\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%b outputs abbreviated month name',
+                input: [ '+%b' ],
+                options: { utc: true },
+                expectedStdout: 'Mar\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%B outputs full month name',
+                input: [ '+%B' ],
+                options: { utc: true },
+                expectedStdout: 'March\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%c outputs full date and time',
+                input: [ '+%c' ],
+                options: { utc: true },
+                expectedStdout: '3/7/2024, 1:05:07 PM\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%C outputs century as 2 digits',
+                input: [ '+%C' ],
+                options: { utc: true },
+                expectedStdout: '20\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%d outputs day of the month as 2 digits',
+                input: [ '+%d' ],
+                options: { utc: true },
+                expectedStdout: '07\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%D outputs date as mm/dd/yy',
+                input: [ '+%D' ],
+                options: { utc: true },
+                expectedStdout: '03/07/24\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%e outputs day of the month as 2 characters padded with a leading space',
+                input: [ '+%e' ],
+                options: { utc: true },
+                expectedStdout: ' 7\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%H outputs the 24-hour clock hour, as 2 digits',
+                input: [ '+%H' ],
+                options: { utc: true },
+                expectedStdout: '13\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%h outputs the same as %b',
+                input: [ '+%h' ],
+                options: { utc: true },
+                expectedStdout: 'Mar\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%I outputs the 12-hour clock hour, as 2 digits',
+                input: [ '+%I' ],
+                options: { utc: true },
+                expectedStdout: '01\n',
+                expectedStderr: '',
+            },
+            // TODO: %j outputs the day of the year as a 3-digit number, starting at 001.
+            {
+                description: '%m outputs the month, as 2 digits, with January as 01',
+                input: [ '+%m' ],
+                options: { utc: true },
+                expectedStdout: '03\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%M outputs the minute, as 2 digits',
+                input: [ '+%M' ],
+                options: { utc: true },
+                expectedStdout: '05\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%n outputs a newline character',
+                input: [ '+%n' ],
+                options: { utc: true },
+                expectedStdout: '\n\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%p outputs AM or PM',
+                input: [ '+%p' ],
+                options: { utc: true },
+                expectedStdout: 'PM\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%r outputs the 12-hour clock time',
+                input: [ '+%r' ],
+                options: { utc: true },
+                expectedStdout: '01:05:07 PM\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%S outputs seconds, as 2 digits',
+                input: [ '+%S' ],
+                options: { utc: true },
+                expectedStdout: '07\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%t outputs a tab character',
+                input: [ '+%t' ],
+                options: { utc: true },
+                expectedStdout: '\t\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%T outputs the 24-hour clock time',
+                input: [ '+%T' ],
+                options: { utc: true },
+                expectedStdout: '13:05:07\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%u outputs the week day as a number, with Monday = 1 and Sunday = 7',
+                input: [ '+%u' ],
+                options: { utc: true },
+                expectedStdout: '4\n',
+                expectedStderr: '',
+            },
+            // TODO: %U outputs the week of the year, as 2 digits, with weeks starting on Sunday, and the first being week 00
+            // TODO: %V outputs the week of the year, as 2 digits, with weeks starting on Monday, and the first being week 01
+            {
+                description: '%w outputs the week day as a number, with Sunday = 0 and Saturday = 6',
+                input: [ '+%w' ],
+                options: { utc: true },
+                expectedStdout: '4\n',
+                expectedStderr: '',
+            },
+            // TODO: %W outputs the week of the year, as 2 digits,, with weeks starting on Monday, and the first being week 00
+            {
+                description: '%x outputs a local date representation',
+                input: [ '+%x' ],
+                options: { utc: true },
+                expectedStdout: '3/7/2024\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%X outputs a local time representation',
+                input: [ '+%X' ],
+                options: { utc: true },
+                expectedStdout: '1:05:07 PM\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%y outputs the year within a century, as 2 digits',
+                input: [ '+%y' ],
+                options: { utc: true },
+                expectedStdout: '24\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%Y outputs the year',
+                input: [ '+%Y' ],
+                options: { utc: true },
+                expectedStdout: '2024\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%Z outputs the timezone name',
+                input: [ '+%Z' ],
+                options: { utc: true },
+                expectedStdout: 'UTC\n',
+                expectedStderr: '',
+            },
+            {
+                description: '%% outputs a percent sign',
+                input: [ '+%%' ],
+                options: { utc: true },
+                expectedStdout: '%\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'multiple format sequences can be included at once',
+                input: [ '+%B is month %m' ],
+                options: { utc: true },
+                expectedStdout: 'March is month 03\n',
+                expectedStderr: '',
+            },
+            {
+                description: 'unrecognized formats are output verbatim',
+                input: [ '+%4%L hello' ],
+                options: { utc: true },
+                expectedStdout: '%4%L hello\n',
+                expectedStderr: '',
+            },
+        ];
+
+        for (const { description, input, options, expectedStdout, expectedStderr, expectedFail } of testCases) {
+            it(description, async () => {
+                let ctx = MakeTestContext(builtins.date, { positionals: input, values: options });
+                let hadError = false;
+                try {
+                    const result = await builtins.date.execute(ctx);
+                    if (!expectedFail) {
+                        assert.equal(result, undefined, 'should exit successfully, returning nothing');
+                    }
+                } catch (e) {
+                    hadError = true;
+                    if (!expectedFail) {
+                        assert.fail(e);
+                    }
+                }
+                if (expectedFail && !hadError) {
+                    assert.fail('should have returned an error code');
+                }
+                assert.equal(ctx.externs.out.output, expectedStdout, 'wrong output written to stdout');
+                assert.equal(ctx.externs.err.output, expectedStderr, 'wrong output written to stderr');
+            });
+        }
+    });
+};


### PR DESCRIPTION
~~This is using the mockdate package, so that we can force `new Date()` to return a specific value. Otherwise, it would be really unpleasant to try and make these reliable!~~

Now using `chronokinesis`. I'm not sure it's actually necessary, but I switched to it as part of trying to make the timezone names consistent, and it seems like it can't hurt. It also has a *much* cooler name. :sunglasses: 