### PR TITLE
Prevent ReferenceErrors caused by reading `process` from the browser

### DIFF
--- a/src/ansi-shell/ANSIShell.js
+++ b/src/ansi-shell/ANSIShell.js
@@ -113,7 +113,7 @@ export class ANSIShell extends EventTarget {
     }
 
     async doPromptIteration() {
-        if ( globalThis.force_eot ) {
+        if ( globalThis.force_eot && typeof process !== 'undefined' ) {
             process.exit(0);
         }
         const { readline } = this.ctx.externs;

--- a/src/ansi-shell/pipeline/Pipeline.js
+++ b/src/ansi-shell/pipeline/Pipeline.js
@@ -288,8 +288,11 @@ export class PreparedCommand {
         //        but for some reason Node crashes first, unless we set this handler,
         //        EVEN IF IT DOES NOTHING. I also can't find a place to safely remove it,
         //        so apologies if it makes debugging promises harder.
-        const rejectionCatcher = (reason, promise) => {};
-        process.on('unhandledRejection', rejectionCatcher);
+        if (typeof process !== 'undefined') {
+            const rejectionCatcher = (reason, promise) => {
+            };
+            process.on('unhandledRejection', rejectionCatcher);
+        }
 
         let exit_code = 0;
         try {

--- a/src/ansi-shell/readline/readline.js
+++ b/src/ansi-shell/readline/readline.js
@@ -74,7 +74,7 @@ const ReadlineProcessorBuilder = builder => builder
             externs.out.write('^C\n');
             // Exit if input line is empty
             // FIXME: Check for 'process' is so we only do this on Node. How should we handle exiting in Puter terminal?
-            if ( process && ctx.vars.result.length === 0 ) {
+            if ( typeof process !== 'undefined' && ctx.vars.result.length === 0 ) {
                 process.exit(1);
                 return;
             }


### PR DESCRIPTION
`process` only exists when running in Node. Notably, `if (process)` is still a ReferenceError, so the existing checks need modifying too.