### PR TITLE
Fix a couple of issues with the web build, caused by CLI changes

### DIFF
--- a/src/ansi-shell/ANSIShell.js
+++ b/src/ansi-shell/ANSIShell.js
@@ -113,7 +113,7 @@ export class ANSIShell extends EventTarget {
     }
 
     async doPromptIteration() {
-        if ( globalThis.force_eot ) {
+        if ( globalThis.force_eot && this.ctx.platform.name === 'node' ) {
             process.exit(0);
         }
         const { readline } = this.ctx.externs;

--- a/src/ansi-shell/pipeline/Pipeline.js
+++ b/src/ansi-shell/pipeline/Pipeline.js
@@ -288,8 +288,10 @@ export class PreparedCommand {
         //        but for some reason Node crashes first, unless we set this handler,
         //        EVEN IF IT DOES NOTHING. I also can't find a place to safely remove it,
         //        so apologies if it makes debugging promises harder.
-        const rejectionCatcher = (reason, promise) => {};
-        process.on('unhandledRejection', rejectionCatcher);
+        if (ctx.platform.name === 'node') {
+            const rejectionCatcher = (reason, promise) => { };
+            process.on('unhandledRejection', rejectionCatcher);
+        }
 
         let exit_code = 0;
         try {

--- a/src/ansi-shell/readline/readline.js
+++ b/src/ansi-shell/readline/readline.js
@@ -74,7 +74,7 @@ const ReadlineProcessorBuilder = builder => builder
             externs.out.write('^C\n');
             // Exit if input line is empty
             // FIXME: Check for 'process' is so we only do this on Node. How should we handle exiting in Puter terminal?
-            if ( process && ctx.vars.result.length === 0 ) {
+            if ( typeof process !== 'undefined' && ctx.vars.result.length === 0 ) {
                 process.exit(1);
                 return;
             }

--- a/src/puter-shell/main.js
+++ b/src/puter-shell/main.js
@@ -28,7 +28,6 @@ import { Context } from "contextlink";
 import { SHELL_VERSIONS } from "../meta/versions.js";
 import { PuterShellParser } from "../ansi-shell/parsing/PuterShellParser.js";
 import { BuiltinCommandProvider } from "./providers/BuiltinCommandProvider.js";
-import { PathCommandProvider } from "./providers/PathCommandProvider.js";
 import { CreateChatHistoryPlugin } from './plugins/ChatHistoryPlugin.js';
 import { Pipe } from '../ansi-shell/pipeline/Pipe.js';
 import { Coupler } from '../ansi-shell/pipeline/Coupler.js';
@@ -83,10 +82,15 @@ export const launchPuterShell = async (ctx) => {
         await sdkv2.setAPIOrigin(source_without_trailing_slash);
     }
 
+    // PathCommandProvider is only compatible with node.js for now
+    // HACK: The import path is split to fool rollup into not including it.
+    const { PathCommandProvider } = (ctx.platform.name === 'node')
+        ? await import('./providers/' + 'PathCommandProvider.js')
+        : { PathCommandProvider: null };
+
     const commandProvider = new CompositeCommandProvider([
         new BuiltinCommandProvider(),
-        // PathCommandProvider is only compatible with node.js for now
-        ...(ctx.platform.name === 'node' ? [new PathCommandProvider()] : []),
+        ...(PathCommandProvider ? [new PathCommandProvider()] : []),
         new ScriptCommandProvider(),
     ]);
 


### PR DESCRIPTION
Avoid including PathCommandProvider and its dependencies in the web build, because they're useless there, and they try to include some binary files that make rollup upset.

Also redo the changes originally in #79 because we can read `ctx.platform.name` in most places, and that makes the check clearer.